### PR TITLE
updated

### DIFF
--- a/examples/01_variables_and_types.tr
+++ b/examples/01_variables_and_types.tr
@@ -1,0 +1,192 @@
+# 01 — Variables and Types
+# Covers: immutable/mutable variables, const, all primitive types,
+# numeric literals, type inference, the 'as' cast operator, none.
+
+def main():
+
+    # ── 1. Immutable variables (default) ─────────────────────────────────────
+    # Variables without 'mut' cannot be reassigned after declaration.
+    print("=== Immutable Variables ===")
+    name:    str   = "Tauraro"   # explicit type annotation
+    version: int   = 2            # type inferred: int
+    pi:      float = 3.14159     # explicit float annotation
+
+    print(name)
+    print(f"version: {version}")
+    print(f"pi: {pi}")
+    # name = "other"  # ERROR [M-6]: cannot assign to immutable binding
+
+    # ── 2. Mutable variables ──────────────────────────────────────────────────
+    print("=== Mutable Variables ===")
+    mut count = 0
+    count = count + 1   # reassignment allowed
+    count += 2          # augmented assignment
+    print(f"count: {count}")   # 3
+
+    mut x: int = 10
+    x = 20
+    print(f"x: {x}")   # 20
+
+    # ── 3. Constants ──────────────────────────────────────────────────────────
+    # Evaluated at compile time, inlined wherever used — like C #define.
+    print("=== Constants ===")
+    const MAX_CONNECTIONS = 1024
+    const APP_NAME        = "Tauraro"
+    const FLAG_READ       = 0x01
+    const FLAG_WRITE      = 0x02
+
+    print(APP_NAME)
+    print(f"max: {MAX_CONNECTIONS}")
+    print(f"read|write: {FLAG_READ | FLAG_WRITE}")   # 3
+
+    # ── 4. Integer types ──────────────────────────────────────────────────────
+    # int (64-bit) is the default. Use fixed-width types for FFI/protocols.
+    print("=== Integer Types ===")
+    big:   int   = 9_000_000_000   # long long — default integer type
+    med:   i32   = 2_147_483_647   # int — 32-bit signed
+    sml:   i16   = 32_767          # short — 16-bit signed
+    tiny:  i8    = 127             # int8_t — 8-bit signed
+    ubig:  u64   = 18_000_000_000  # unsigned long long
+    ubyte: u8    = 255             # uint8_t — byte / pixel data
+    sz:    usize = 4096            # size_t — for sizes and indices
+
+    print(f"int:   {big}")
+    print(f"i32:   {med}")
+    print(f"u8:    {ubyte}")
+    print(f"usize: {sz}")
+
+    # ── 5. Float types ────────────────────────────────────────────────────────
+    # float/f64 (64-bit double) is default. f32 saves memory in large arrays.
+    print("=== Float Types ===")
+    fa: float = 3.14159     # double — default float type
+    fb: f64   = 2.71828     # identical to float
+    fc: f32   = 1.41 as f32 # float — 32-bit, lower precision
+
+    # print() and f-strings both handle floats natively (using %g format)
+    print(fa)
+    print(f"f64: {fb}")
+    print(f"f32: {fc}")
+
+    # Scientific notation
+    big_f:  float = 1.5e10
+    tiny_f: float = 1.5e-7
+    print(f"1.5e10:  {big_f}")
+    print(f"1.5e-7:  {tiny_f}")
+
+    # ── 6. Boolean ────────────────────────────────────────────────────────────
+    print("=== Boolean ===")
+    active:   bool = true
+    disabled: bool = false
+
+    print(active)          # true  (print handles bool natively)
+    print(disabled)        # false
+    print(f"active: {active}, disabled: {disabled}")
+
+    # ── 7. Character ──────────────────────────────────────────────────────────
+    # char = single byte (ASCII). Not a Unicode code point.
+    print("=== Character ===")
+    letter:  char = 'A'
+    tab_ch:  char = '\t'
+    null_ch: char = '\0'
+
+    print(f"char: {letter}")
+    print(f"ASCII value: {ord(letter)}")   # ord() is a built-in: char → int
+    print(f"chr(66): {chr(66)}")           # chr() is a built-in: int → char
+
+    # ── 8. String ─────────────────────────────────────────────────────────────
+    # str = C char* — null-terminated UTF-8. Literals live in read-only memory.
+    print("=== String ===")
+    greeting: str = "Hello, world!"
+    empty:    str = ""
+    escapes:  str = "tab:\there\nnewline"
+    path:     str = "C:\\Users\\Tauraro"
+    quoted:   str = "She said \"hello\""
+
+    print(greeting)
+    print(escapes)
+    print(f"len: {len(greeting)}")
+
+    # ── 9. Numeric literals ───────────────────────────────────────────────────
+    print("=== Numeric Literals ===")
+    decimal:     int = 42
+    readability: int = 1_000_000    # underscores for readability
+    hex_val:     int = 0xFF         # 255
+    binary_val:  int = 0b1010_1010  # 170
+    octal_val:   int = 0o755        # 493
+
+    print(f"1_000_000 = {readability}")
+    print(f"0xFF      = {hex_val}")
+    print(f"0b1010_1010 = {binary_val}")
+    print(f"0o755     = {octal_val}")
+
+    # ── 10. Type inference ────────────────────────────────────────────────────
+    # Compiler infers from the initializer — annotations optional for locals.
+    print("=== Type Inference ===")
+    auto_int:   int   = 42        # int
+    auto_float: float = 3.14      # float
+    auto_str:   str   = "hello"   # str
+    auto_bool:  bool  = true      # bool
+    auto_char:  char  = 'Z'       # char
+
+    print(f"int={auto_int}  float={auto_float}  str={auto_str}")
+
+    # Force a non-default type when you need it:
+    small_int: i32 = 42 as i32    # force 32-bit
+    byte_val:  u8  = 200 as u8    # force unsigned byte
+    print(f"i32={small_int as int}  u8={byte_val as int}")
+
+    # ── 11. The 'as' cast operator ────────────────────────────────────────────
+    # All type coercions must be EXPLICIT — Tauraro never coerces silently.
+    print("=== 'as' Cast ===")
+    n: int = 1000
+    f: float = n as float      # int → float (widening, exact)
+    back: int = f as int       # float → int (truncates toward 0)
+    print(f"1000 as float as int = {back}")   # 1000
+
+    f2: float = 3.99
+    i2: int   = f2 as int      # truncates — 3, NOT 4
+    print(f"3.99 as int = {i2}")              # 3
+
+    wrapping: i8 = 300 as i8   # 300 mod 256 = 44
+    print(f"300 as i8 = {wrapping as int}")   # 44
+
+    zero_bool: bool = 0 as bool   # any zero → false
+    one_bool:  bool = 5 as bool   # any non-zero → true
+    print(f"0 as bool = {zero_bool}  5 as bool = {one_bool}")
+
+    # ── 12. str() and other conversion builtins ───────────────────────────────
+    # str(x) is a built-in that converts any value to its string representation.
+    print("=== str() Conversions ===")
+    s_int:   str = str(42)         # "42"
+    s_float: str = str(3.14)       # "3.14"
+    s_bool:  str = str(true)       # "true"
+
+    print(s_int)
+    print(s_float)
+    print(s_bool)
+
+    # Parsing strings back to numbers:
+    mut parsed_int   = int("123")       # 123
+    mut parsed_float = float("9.81")    # 9.81
+    print(f"parsed int:   {parsed_int}")
+    print(f"parsed float: {parsed_float}")
+
+    # ── 13. none — the null value ────────────────────────────────────────────
+    # 'none' is only valid for Option[T].
+    # Assigning none to bare int/float/bool/str causes a compile error [M-7].
+    print("=== none / Option ===")
+    mut opt: Option[str] = Option.None
+    match opt:
+        case Option.None:
+            print("opt is none")
+        case Option.Some(v):
+            print(v)
+
+    opt = Option.Some("assigned")
+    match opt:
+        case Option.Some(v):
+            print(v)
+        case Option.None:
+            pass
+
+    print("=== done ===")

--- a/examples/02_operators.tr
+++ b/examples/02_operators.tr
@@ -1,0 +1,158 @@
+# 02 — Operators
+# Covers: arithmetic, comparison, logical, bitwise, augmented assignment,
+# 'in' membership, operator precedence, and the 'as' cast operator.
+
+def main():
+
+    # ── 1. Arithmetic operators ───────────────────────────────────────────────
+    print("=== Arithmetic ===")
+    print(f"10 + 3  = {10 + 3}")    # 13
+    print(f"10 - 3  = {10 - 3}")    # 7
+    print(f"10 * 3  = {10 * 3}")    # 30
+    print(f"10 / 3  = {10 / 3}")    # 3  (integer division — truncates toward 0)
+    print(f"10 % 3  = {10 % 3}")    # 1  (modulo)
+    print(f"-10     = {-10}")       # unary negation
+
+    # CRITICAL: '/' on two int operands is INTEGER division.
+    # To get a float result, cast at least one operand first:
+    print(f"10 / 3 (int)   = {10 / 3}")              # 3
+    print(f"10.0 / 3 (float) = {10.0 / 3 as float}") # 3.333...
+
+    # Wrong order matters:
+    mut wrong: float = (10 / 3) as float    # 3.0  — division first, then cast
+    mut right: float = 10 as float / 3      # 3.333...  — cast first, then divide
+    print(f"(10/3) as float = {wrong}")
+    print(f"10 as float / 3 = {right}")
+
+    # Modulo sign follows the dividend (left operand) — like C:
+    print(f"-10 % 3  = {-10 % 3}")   # -1
+    print(f"10 % -3  = {10 % -3}")   # 1
+
+    # ── 2. Comparison operators ───────────────────────────────────────────────
+    # All comparisons produce a bool.
+    print("=== Comparison ===")
+    a: int = 10
+    b: int = 20
+    print(f"10 == 20: {a == b}")    # false
+    print(f"10 != 20: {a != b}")    # true
+    print(f"10 <  20: {a < b}")     # true
+    print(f"10 >  20: {a > b}")     # false
+    print(f"10 <= 10: {a <= a}")    # true
+    print(f"10 >= 20: {a >= b}")    # false
+
+    # String comparison uses strcmp — content equality, not pointer equality:
+    s1: str = "hello"
+    s2: str = "hello"
+    s3: str = "world"
+    print("hello == hello: " + str(s1 == s2))   # true
+    print("hello <  world: " + str(s1 < s3))    # true (lexicographic)
+
+    # ── 3. Logical operators ──────────────────────────────────────────────────
+    print("=== Logical ===")
+    t: bool = true
+    f_val: bool = false
+
+    print(f"true and false: {t and f_val}")   # false
+    print(f"true or  false: {t or f_val}")    # true
+    print(f"not true:       {not t}")         # false
+
+    # Short-circuit: right side is NOT evaluated if result is already known.
+    # 'and' stops at first false; 'or' stops at first true.
+    # Short-circuit: 'and' stops at first false, 'or' stops at first true.
+    mut y = 42
+    if y > 0 and y < 100:
+        print("y is in range")      # both sides evaluated only when needed
+
+    mut zz = -5
+    if zz < 0 or zz > 100:
+        print("zz is out of normal range")   # second side skipped
+
+    # ── 4. Bitwise operators ──────────────────────────────────────────────────
+    print("=== Bitwise ===")
+    mut p: int = 5    # 0b0101
+    mut q: int = 6    # 0b0110
+
+    print(f"0b0101 & 0b0110 = {p & q}")    # 0b0100 = 4  (AND)
+    print(f"0b0101 | 0b0110 = {p | q}")    # 0b0111 = 7  (OR)
+    print(f"0b0101 ^ 0b0110 = {p ^ q}")    # 0b0011 = 3  (XOR)
+    print(f"~0b0101          = {~p}")       # -6           (NOT — all bits flipped)
+    print(f"1 << 3           = {1 << 3}")  # 8            (left shift)
+    print(f"32 >> 2          = {32 >> 2}") # 8            (right shift)
+
+    # Classic flag-manipulation pattern:
+    const PERM_READ  = 1 << 0   # 0b001
+    const PERM_WRITE = 1 << 1   # 0b010
+    const PERM_EXEC  = 1 << 2   # 0b100
+
+    mut perms = PERM_READ | PERM_WRITE    # grant read + write
+    print(f"perms = {perms}")             # 3
+
+    if (perms & PERM_READ) != 0:
+        print("read allowed")
+
+    perms = perms & ~PERM_WRITE    # revoke write
+    perms = perms ^ PERM_EXEC      # toggle exec
+    print(f"after changes: {perms}")    # 5 (read + exec)
+
+    # ── 5. Augmented assignment ───────────────────────────────────────────────
+    # Only works on 'mut' variables.
+    print("=== Augmented Assignment ===")
+    mut n = 10
+    n += 5    # n = n + 5  → 15
+    n -= 3    # n = n - 3  → 12
+    n *= 2    # n = n * 2  → 24
+    n /= 4    # n = n / 4  → 6  (integer division)
+    n %= 4    # n = n % 4  → 2
+    print(f"n after +=5 -=3 *=2 /=4 %%=4: {n}")   # 2
+
+    # ── 6. The 'in' / 'not in' membership operators ──────────────────────────
+    print("=== 'in' Membership ===")
+    mut items: List[int] = [1, 2, 3, 4, 5]
+
+    # Direct 'in' on a List:
+    if 3 in items:
+        print("3 is in items")
+    if 99 not in items:
+        print("99 is not in items")
+
+    # 'in' on a string checks for substring:
+    msg: str = "Hello, Tauraro!"
+    if "Tauraro" in msg:
+        print("found Tauraro in msg")
+    if "Python" not in msg:
+        print("Python not in msg")
+
+    # ── 7. Operator precedence ────────────────────────────────────────────────
+    # From highest to lowest: () . [] call | unary | as | * / % | + - |
+    # << >> | & | ^ | | | comparisons | not | and | or | =
+    print("=== Precedence ===")
+
+    # DANGER: bitwise & has LOWER precedence than ==
+    # This is parsed as: x & (1 == 1)  which is: x & true  → wrong!
+    x = 5
+    mut wrong_check: int = x & 1 == 1   # parsed as: x & (1 == 1) = 5 & 1 = 1 (truthy but wrong semantics)
+    mut right_check: bool = (x & 1) == 1  # correct: test if bit 0 is set
+    print("x & 1 == 1  (ambiguous): " + str(wrong_check))
+    print("(x & 1) == 1 (correct):  " + str(right_check))
+
+    # Always parenthesize when mixing bitwise and comparison:
+    mut result: int = (10 + 20 * 2) & 0xFF    # clear: add with doubled b, then mask
+    print(f"(10 + 20*2) & 0xFF = {result}")   # 50
+
+    # Unary minus has higher precedence than *:
+    print(f"-2 * 3 = {-2 * 3}")   # -6
+
+    # 'as' binds tighter than arithmetic:
+    mut mixed: float = 10 as float / 3   # (10 as float) / 3 = 3.333
+    print(f"10 as float / 3 = {mixed}")
+
+    # ── 8. Built-in math helpers ──────────────────────────────────────────────
+    print("=== Built-in Math ===")
+    print(f"abs(-42)    = {abs(-42)}")        # 42
+    print(f"abs(-3.14)  = {abs(-3.14)}")      # 3.14
+    print(f"min(5, 3)   = {min(5, 3)}")       # 3
+    print(f"max(5, 3)   = {max(5, 3)}")       # 5
+    print(f"round(3.7)  = {round(3.7)}")      # 4.0
+    print(f"round(3.2)  = {round(3.2)}")      # 3.0
+
+    print("=== done ===")

--- a/examples/03_control_flow.tr
+++ b/examples/03_control_flow.tr
@@ -1,0 +1,222 @@
+# 03 — Control Flow
+# Covers: if/elif/else, ternary, while, for (range/list/enumerate),
+# break, continue, match (value and enum), pass.
+
+enum Direction:
+    North
+    South
+    East
+    West
+
+enum Shape:
+    Circle(radius: int)
+    Rect(width: int, height: int)
+    Point
+
+def main():
+
+    # ── 1. if / elif / else ───────────────────────────────────────────────────
+    print("=== if / elif / else ===")
+    score = 85
+
+    if score >= 90:
+        print("A")
+    elif score >= 80:
+        print("B")
+    elif score >= 70:
+        print("C")
+    else:
+        print("F")
+
+    # ── 2. Inline (single-statement) if ──────────────────────────────────────
+    # When the body is exactly one statement it can go on the same line.
+    # Best used for short guards and early exits.
+    print("=== Inline if ===")
+    mut value = -5
+    if value < 0: value = 0     # clamp to zero
+    print(f"clamped: {value}")  # 0
+
+    x = 10
+    if x > 0: print("positive")
+
+    # ── 3. Ternary expression ─────────────────────────────────────────────────
+    # Both branches must have the same type.
+    print("=== Ternary ===")
+    label:       str = "pass" if score >= 60 else "fail"
+    mut sign:    int = 1 if x > 0 else -1
+    mut abs_val: int = x if x >= 0 else -x
+
+    print(f"label: {label}")    # pass
+    print(f"sign:  {sign}")     # 1
+    print(f"abs:   {abs_val}")  # 10
+
+    # ── 4. Compound conditions ────────────────────────────────────────────────
+    print("=== Compound Conditions ===")
+    age  = 25
+    role = "admin"
+
+    if age >= 18 and age < 65:
+        print("working age")
+
+    if role == "admin" or role == "root":
+        print("privileged access")
+
+    if not (age < 18):
+        print("adult")
+
+    # ── 5. while loop ─────────────────────────────────────────────────────────
+    print("=== while ===")
+    mut i = 1
+    while i <= 5:
+        print(f"  i = {i}")
+        i = i + 1
+
+    # ── 6. while true + break ─────────────────────────────────────────────────
+    print("=== while true + break ===")
+    mut n = 0
+    while true:
+        n += 1
+        if n >= 3: break
+    print(f"n after break: {n}")   # 3
+
+    # ── 7. break and continue ─────────────────────────────────────────────────
+    print("=== break / continue ===")
+    mut k = 0
+    while k < 10:
+        k += 1
+        if k % 2 == 0: continue    # skip even numbers
+        if k > 7: break            # stop after 7
+        print(f"  {k}")            # 1 3 5 7
+
+    # ── 8. for range (basic) ──────────────────────────────────────────────────
+    # range(n) → 0, 1, ..., n-1
+    print("=== for range ===")
+    for i in range(5):
+        print(f"  {i}")   # 0 1 2 3 4
+
+    # range(start, stop)
+    for i in range(1, 6):
+        print(f"  {i}")   # 1 2 3 4 5
+
+    # range(start, stop, step)
+    for i in range(0, 10, 2):
+        print(f"  {i}")   # 0 2 4 6 8
+
+    # countdown
+    print("=== countdown ===")
+    mut cd: int = 5
+    while cd > 0:
+        print(f"  {cd}")
+        cd -= 1
+
+    # ── 9. for over a list ────────────────────────────────────────────────────
+    print("=== for list ===")
+    mut names: List[str] = ["Alice", "Bob", "Charlie"]
+    mut ni: int = 0
+    while ni < len(names):
+        mut nm: str = names[ni + 0]
+        print(f"  Hello, {nm}!")
+        ni += 1
+
+    scores = [92, 78, 65, 88]
+    mut total = 0
+    for s in scores:
+        total += s
+    print(f"total: {total}")   # 323
+
+    # ── 10. for with enumerate ────────────────────────────────────────────────
+    # enumerate(list) gives (index, value) pairs.
+    print("=== enumerate ===")
+    mut fruits: List[str] = ["apple", "banana", "cherry"]
+    mut ei = 0
+    while ei < len(fruits):
+        mut fname: str = fruits[ei + 0]
+        print(f"  [{ei}] {fname}")
+        ei += 1
+
+    # ── 11. Nested loops — break only exits innermost ─────────────────────────
+    # Use a flag variable to break out of nested loops.
+    print("=== Nested loops + flag ===")
+    mut found = false
+    mut row = 0
+    while row < 3 and not found:
+        mut col = 0
+        while col < 3:
+            if row == 1 and col == 2:
+                found = true
+                break
+            col += 1
+        row += 1
+    print(f"found at row={row - 1}, col=2: {found}")
+
+    # ── 12. match — value matching ────────────────────────────────────────────
+    # match dispatches on discrete values. 'case _:' is the wildcard.
+    print("=== match value ===")
+    code = 404
+
+    match code:
+        case 200: print("OK")
+        case 201: print("Created")
+        case 400: print("Bad Request")
+        case 404: print("Not Found")
+        case 500: print("Server Error")
+        case _:   print(f"Unknown: {code}")
+
+    # ── 13. match — enum with destructuring ───────────────────────────────────
+    print("=== match enum ===")
+    mut dir = Direction.North
+    match dir:
+        case Direction.North: print("heading north")
+        case Direction.South: print("heading south")
+        case Direction.East:  print("heading east")
+        case Direction.West:  print("heading west")
+        case _: pass
+
+    # Enum variants that carry data — fields are bound as local variables.
+    match Shape.Circle(5):
+        case Shape.Circle(r):
+            print(f"circle area = {r * r * 3}")
+        case _: pass
+    match Shape.Rect(3, 4):
+        case Shape.Rect(w, h):
+            print(f"rect area = {w * h}")
+        case _: pass
+    match Shape.Point:
+        case Shape.Point:
+            print("point (area = 0)")
+        case _: pass
+
+    # ── 14. pass — explicit no-op ─────────────────────────────────────────────
+    # 'pass' marks an intentionally empty block.
+    print("=== pass ===")
+    flag = true
+    if flag:
+        pass    # nothing to do — placeholder
+
+    match dir:
+        case Direction.North: print("north")
+        case _: pass          # all other directions: do nothing
+
+    # ── 15. Scoping — variables live only in their block ──────────────────────
+    print("=== Scoping ===")
+    mut outer = 10
+    if true:
+        mut inner = 20
+        outer = outer + inner   # outer is in scope here
+    # inner is out of scope here
+    print(f"outer: {outer}")   # 30
+    # print(inner)             # ERROR: 'inner' is not in scope
+
+    # ── 16. FizzBuzz — combining everything ───────────────────────────────────
+    print("=== FizzBuzz (1..20) ===")
+    for i in range(1, 21):
+        if i % 15 == 0:
+            print("FizzBuzz")
+        elif i % 3 == 0:
+            print("Fizz")
+        elif i % 5 == 0:
+            print("Buzz")
+        else:
+            print(str(i))
+
+    print("=== done ===")

--- a/examples/04_functions.tr
+++ b/examples/04_functions.tr
@@ -1,0 +1,183 @@
+# 04 — Functions
+# Covers: def, parameters, return types, early return, decorators
+# (@inline, @hot, @cold), closures (lambda), generic functions,
+# throws / ? error propagation, async functions.
+
+# ── 1. Basic function definition ─────────────────────────────────────────────
+def add(a: int, b: int) -> int:
+    return a + b
+
+def greet(name: str) -> void:
+    print(f"Hello, {name}!")
+
+def write_log(msg: str):       # void return type is optional
+    print(msg)
+
+# ── 2. Multiple parameters and explicit return ────────────────────────────────
+def clamp(value: int, lo: int, hi: int) -> int:
+    if value < lo: return lo
+    if value > hi: return hi
+    return value
+
+# ── 3. All code paths must return (rule F-3) ─────────────────────────────────
+def classify(n: int) -> str:
+    if n > 0:   return "positive"
+    elif n < 0: return "negative"
+    else:       return "zero"    # all paths covered — no compiler error
+
+# ── 4. Early return for guard clauses ────────────────────────────────────────
+def safe_divide(a: int, b: int) -> int:
+    if b == 0: return 0          # guard: exit early on bad input
+    return a / b
+
+# ── 5. @inline — force inlining for small hot functions ──────────────────────
+@inline
+def square(x: int) -> int:
+    return x * x
+
+@inline
+def is_even(n: int) -> bool:
+    return n % 2 == 0
+
+# ── 6. @hot / @cold — branch prediction hints ────────────────────────────────
+@hot
+def hot_path(x: int) -> int:     # called frequently — tell GCC to optimize
+    return x * x + x + 1
+
+@cold
+def error_handler(msg: str) -> void:   # rarely called — GCC deprioritizes
+    print(f"ERROR: {msg}")
+
+# ── 7. Generic functions — work with any type ─────────────────────────────────
+# [T] declares a type parameter. Compiler generates a concrete version per type.
+def identity[T](x: T) -> T:
+    return x
+
+def first[T](items: List[T]) -> T:
+    return items[0]
+
+def clamp_generic[T](v: T, lo: T, hi: T) -> T:
+    if v < lo: return lo
+    if v > hi: return hi
+    return v
+
+# ── 8. throws — functions that can fail ──────────────────────────────────────
+# 'throws ErrorType' changes the return type to Result[ReturnType, ErrorType].
+# Inside: 'return value' wraps as Ok, 'raise(err)' wraps as Err and returns.
+def parse_positive(s: str) throws str -> int:
+    if len(s) == 0:
+        raise("empty string")
+    mut n = int(s)
+    if n <= 0:
+        raise(f"expected positive number, got: {s}")
+    return n
+
+# ── 9. ? — propagate errors up the call chain ─────────────────────────────────
+# '?' after a throws call: unwraps success value OR propagates error to caller.
+def doubled(s: str) throws str -> int:
+    mut n = parse_positive(s)?   # if parse_positive fails, return its error
+    return n * 2
+
+def quadrupled(s: str) throws str -> int:
+    mut n = doubled(s)?          # if doubled fails, propagate
+    return n * 2
+
+# ── 10. Higher-order functions (lambda types not yet fully supported) ─────────
+# Pass functions by using named function references.
+def add_n(x: int, n: int) -> int:
+    return x + n
+
+def apply_sq(x: int) -> int:
+    return x * x
+
+# ── 11. Async functions ───────────────────────────────────────────────────────
+# 'async' marks a function as a coroutine. Today it compiles identically to a
+# normal function (synchronous), but the syntax is forward-compatible with a
+# future async runtime.
+async def fetch_data(id: int) -> str:
+    return f"item-{id}"
+
+async def process(id: int) -> int:
+    mut data: str = await fetch_data(id)
+    return len(data)
+
+def main():
+
+    # ── Basic calls ───────────────────────────────────────────────────────────
+    print("=== Basic Functions ===")
+    print(f"add(3, 4) = {add(3, 4)}")        # 7
+    greet("Tauraro")
+    write_log("this is a log message")
+
+    # ── Clamp ─────────────────────────────────────────────────────────────────
+    print("=== Clamp ===")
+    print(f"clamp(5, 0, 10)  = {clamp(5, 0, 10)}")    # 5
+    print(f"clamp(-3, 0, 10) = {clamp(-3, 0, 10)}")   # 0
+    print(f"clamp(15, 0, 10) = {clamp(15, 0, 10)}")   # 10
+
+    # ── Classify ──────────────────────────────────────────────────────────────
+    print("=== Classify ===")
+    print(classify(42))     # positive
+    print(classify(-1))     # negative
+    print(classify(0))      # zero
+
+    # ── Safe divide ───────────────────────────────────────────────────────────
+    print("=== Safe Divide ===")
+    print(f"10 / 2 = {safe_divide(10, 2)}")   # 5
+    print(f"10 / 0 = {safe_divide(10, 0)}")   # 0 (guard returned)
+
+    # ── @inline helpers ───────────────────────────────────────────────────────
+    print("=== @inline ===")
+    print(f"square(7)   = {square(7)}")       # 49
+    print(f"is_even(4)  = {is_even(4)}")      # true
+    print(f"is_even(7)  = {is_even(7)}")      # false
+
+    # ── Generic functions (work with pointer types; int generics use void*) ──────
+    print("=== Generics ===")
+    hi_val: str = "hi"
+    mut id_str: str = identity[str](hi_val)
+    print(f"identity[str](hi) = {id_str}")
+
+    # ── throws + ? ────────────────────────────────────────────────────────────
+    print("=== throws + ? ===")
+
+    # Call without ? — get back a Result[int, str]
+    mut r1: Result[int, str] = parse_positive("42")
+    if r1.is_ok:
+        print(f"parsed: {r1.ok}")    # 42
+
+    mut r2: Result[int, str] = parse_positive("-5")
+    if r2.is_err:
+        print(f"error: {r2.err}")    # expected positive number, got: -5
+
+    mut r3: Result[int, str] = parse_positive("")
+    if r3.is_err:
+        print(f"error: {r3.err}")    # empty string
+
+    # Deep chain via ?:
+    mut r4: Result[int, str] = quadrupled("3")
+    if r4.is_ok:
+        print(f"quadrupled(3) = {r4.ok}")   # 12
+
+    abc_val: str = "abc"
+    mut r5: Result[int, str] = quadrupled(abc_val)
+    if r5.is_err:
+        print(f"quadrupled(abc) error: {r5.err}")
+
+    # ── Higher-order functions ───────────────────────────────────────────────
+    print("=== Higher-order functions ===")
+    mut r_add5: int = add_n(3, 5)
+    print(f"add_n(3, 5)  = {r_add5}")    # 8
+    mut r_add10: int = add_n(7, 10)
+    print(f"add_n(7, 10) = {r_add10}")   # 17
+
+    mut result: int = apply_sq(7)
+    print(f"apply_sq(7) = {result}")   # 49
+
+    # ── Async ─────────────────────────────────────────────────────────────────
+    # async functions compile identically to normal functions today
+    print("=== Async (synchronous today) ===")
+    mut r_proc: int = process(42)
+    print(f"process(42) = {r_proc}")   # length of "item-42" = 7
+
+    print("=== done ===")

--- a/examples/05_strings.tr
+++ b/examples/05_strings.tr
@@ -1,0 +1,188 @@
+# 05 — Strings and F-Strings
+# Covers: string literals, escape sequences, concatenation, f-strings,
+# string operations (len/index/methods), type↔string conversion.
+
+def main():
+
+    # ── 1. String literals ────────────────────────────────────────────────────
+    # str = C char* — null-terminated UTF-8 byte sequence.
+    print("=== String Literals ===")
+    plain   = "Hello, world!"
+    empty   = ""
+    escaped = "tab:\there\nnewline"
+    path    = "C:\\Users\\Tauraro"
+    quoted  = "She said \"hello\""
+    single  = 'also valid'        # single quotes work too
+
+    print(plain)
+    print(escaped)
+    print(path)
+    print(quoted)
+
+    # All escape sequences:
+    # \n  newline      \r  carriage return    \t  horizontal tab
+    # \\  backslash    \"  double quote       \'  single quote
+    # \0  null byte
+
+    # ── 2. String length and indexing ─────────────────────────────────────────
+    print("=== Length & Indexing ===")
+    s: str = "Hello"
+    print(f"len: {len(s)}")      # 5
+
+    first_char: char = s[0]     # 'H' — returns char
+    last_char:  char = s[4]     # 'o'
+    print(f"ASCII of H = {ord(first_char)}")   # 72
+    print(f"ASCII of o = {ord(last_char)}")    # 111
+
+    # No bounds checking — always validate when index is not statically known:
+    idx: int = 2
+    if idx < len(s):
+        mut ch_at: char = s[idx + 0]
+        print(f"s[{idx}] ASCII = {ord(ch_at)}")   # 108 = 'l'
+
+    # ── 3. String concatenation ───────────────────────────────────────────────
+    # '+' allocates a new heap string.
+    print("=== Concatenation ===")
+    first  = "Hello"
+    second = "world"
+    combined = first + ", " + second + "!"
+    print(combined)    # Hello, world!
+
+    # Must convert non-strings to str before concatenating:
+    count: int = 42
+    mut result = "count: " + str(count)
+    print(result)    # count: 42
+
+    score: float = 9.5
+    mut line  = "score: " + str(score)
+    print(line)      # score: 9.5
+
+    # ── 4. F-strings ──────────────────────────────────────────────────────────
+    # f"..." evaluates {expressions} at runtime. Type-safe — correct format
+    # specifier is chosen per type (%lld for int, %g for float, etc.)
+    print("=== F-Strings ===")
+    name:    str   = "Tauraro"
+    version: int   = 2
+    pi:      float = 3.14159
+
+    print(f"Hello from {name} v{version}!")
+    print(f"pi = {pi}")
+    print(f"1 + 1 = {1 + 1}")
+    print("len(name) = " + str(len(name)))
+
+    # Arithmetic inside {}:
+    a: int = 10
+    b: int = 3
+    print(f"{a} + {b} = {a + b}")
+    print(f"{a} / {b} = {a / b}")             # integer division
+    print(f"{a} / {b} (float) = {a as float / b}")
+
+    # Boolean in f-string:
+    flag: bool = true
+    print(f"flag = {flag}")    # "flag = true"
+
+    # Method call in {}:
+    word: str = "hello"
+    print(f"upper: {word.upper()}")
+
+    # Assign f-string to a variable (heap-allocated):
+    mut msg = f"name={name}, version={version}"
+    print(msg)
+
+    # ── 5. String methods ─────────────────────────────────────────────────────
+    print("=== String Methods ===")
+    text: str = "  Hello, World!  "
+
+    print(text.upper())             # "  HELLO, WORLD!  "
+    print(text.lower())             # "  hello, world!  "
+    print(text.strip())             # "Hello, World!"
+    mut find_world: int = text.find("World")
+    print(str(find_world))          # 9  (index, or -1 if not found)
+    mut find_xyz: int = text.find("xyz")
+    print(str(find_xyz))            # -1
+
+    replaced: str = text.replace("World", "Tauraro")
+    print(replaced)                 # "  Hello, Tauraro!  "
+
+    csv: str = "one,two,three,four"
+    mut parts: List[str] = csv.split(",")
+    mut pi2: int = 0
+    while pi2 < len(parts):
+        mut p: str = parts[pi2 + 0]
+        print(f"  part: {p}")       # one / two / three / four
+        pi2 += 1
+
+    # ── 6. Type-to-string and string-to-type ──────────────────────────────────
+    print("=== Conversions ===")
+    # str() converts any value to its string representation:
+    s_int   = str(42)        # "42"
+    s_float = str(3.14)      # "3.14"
+    s_bool  = str(true)      # "true"
+    s_neg   = str(-100)      # "-100"
+    print(s_int)
+    print(s_float)
+    print(s_bool)
+
+    # Parsing strings to numbers:
+    mut n_int   = int("123")    # 123
+    mut n_float = float("9.81") # 9.81
+    print(f"int:   {n_int}")
+    print(f"float: {n_float}")
+
+    # ── 7. String comparison ──────────────────────────────────────────────────
+    # == and != compare CONTENT (via strcmp), not pointer identity.
+    print("=== Comparison ===")
+    p1 = "hello"
+    p2 = "hello"
+    p3 = "world"
+
+    print("hello == hello: " + str(p1 == p2))   # true
+    print("hello != world: " + str(p1 != p3))   # true
+    print("hello <  world: " + str(p1 < p3))    # true (lexicographic)
+
+    # ── 8. Accessing raw bytes ────────────────────────────────────────────────
+    # s[i] returns a char. Use ord() to get the byte value.
+    print("=== Raw Bytes ===")
+    bytes_str: str = "ABC"
+    mut bi = 0
+    while bi < len(bytes_str):
+        mut bch: char = bytes_str[bi + 0]
+        print(f"  bytes_str[{bi}] ASCII = {ord(bch)}")   # 65 66 67
+        bi += 1
+
+    # Count occurrences of a character:
+    sentence: str = "banana"
+    target: char  = 'a'
+    mut cnt  = 0
+    mut si   = 0
+    while si < len(sentence):
+        mut sch: char = sentence[si + 0]
+        if sch == target:
+            cnt += 1
+        si += 1
+    print(f"a appears {cnt} times in: {sentence}")   # 3
+
+    # ── 9. Building strings efficiently ───────────────────────────────────────
+    # Repeated '+' in a loop is O(n²). Collect parts then join.
+    print("=== String Building ===")
+    mut data: List[int] = [1, 2, 3, 4, 5]
+    mut parts2: List[str] = []
+    mut di: int = 0
+    while di < len(data):
+        mut num: int = data[di + 0]
+        parts2.append(str(num))
+        di += 1
+
+    mut joined = ""
+    mut ji = 0
+    while ji < len(parts2):
+        if ji > 0: joined = joined + ", "
+        joined = joined + parts2[ji + 0]
+        ji += 1
+    print(f"joined: {joined}")   # 1, 2, 3, 4, 5
+
+    # f-strings inside a loop — each iteration prints directly:
+    for i in range(1, 4):
+        print(f"item {i}")
+
+    print("=== done ===")

--- a/examples/06_collections.tr
+++ b/examples/06_collections.tr
@@ -1,0 +1,240 @@
+# 06 — Collections: List[T] and Dict
+# Covers: List creation, append/pop/index/modify, iteration, enumerate,
+# list comprehension, Dict create/get/set/has, ownership rules.
+
+def sum_list(items: List[int]) -> int:
+    mut total = 0
+    for x in items:
+        total += x
+    return total
+
+def filter_positive(nums: List[int]) -> List[int]:
+    mut result: List[int] = []
+    for x in nums:
+        if x > 0: result.append(x)
+    return result
+
+def reverse_list(items: List[int]) -> List[int]:
+    mut result: List[int] = []
+    for v in items:
+        result.append(v)
+    mut lo = 0
+    mut hi = len(result) - 1
+    while lo < hi:
+        mut tmp = result[lo + 0]
+        result[lo + 0] = result[hi + 0]
+        result[hi + 0] = tmp
+        lo += 1
+        hi -= 1
+    return result
+
+def make_range(n: int) -> List[int]:
+    mut result: List[int] = []
+    for i in range(n):
+        result.append(i)
+    return result    # ownership transferred — no free here
+
+def main():
+
+    # ── 1. Creating lists ──────────────────────────────────────────────────────
+    print("=== Creating Lists ===")
+    mut primes: List[int]  = [2, 3, 5, 7, 11]
+    mut names:  List[str]  = ["Alice", "Bob", "Charlie"]
+    mut flags:  List[bool] = [true, false, true]
+
+    # Empty list — type annotation required (compiler can't infer from nothing):
+    mut scores: List[int] = []
+    mut words:  List[str] = []
+
+    print(f"primes: {len(primes)} elements")
+    print(f"names:  {len(names)} elements")
+
+    # ── 2. Appending elements ─────────────────────────────────────────────────
+    print("=== Append ===")
+    scores.append(90)
+    scores.append(85)
+    scores.append(72)
+    scores.append(61)
+    print(f"scores len: {len(scores)}")    # 4
+
+    # ── 3. Reading elements ────────────────────────────────────────────────────
+    print("=== Indexing ===")
+    print(f"primes[0] = {primes[0]}")    # 2
+    print(f"primes[4] = {primes[4]}")    # 11
+
+    # Last element:
+    mut last: int = primes[len(primes) - 1]
+    print(f"last = {last}")              # 11
+
+    # Bounds checking (always validate when index is not statically known):
+    idx: int = 2
+    if idx < len(primes):
+        print(f"primes[{idx}] = {primes[idx + 0]}")    # 5
+
+    # ── 4. Modifying elements ─────────────────────────────────────────────────
+    print("=== Modify ===")
+    mut vals: List[int] = [10, 20, 30, 40, 50]
+    vals[0] = 99
+    vals[2] += 5
+    print(f"vals[0] = {vals[0]}")   # 99
+    print(f"vals[2] = {vals[2]}")   # 35
+
+    # ── 5. Removing the last element ──────────────────────────────────────────
+    print("=== Pop ===")
+    mut popped: int = vals.pop()
+    print(f"popped: {popped}")          # 50
+    print(f"len after pop: {len(vals)}")  # 4
+
+    # ── 6. Iteration ──────────────────────────────────────────────────────────
+    print("=== Iteration ===")
+    mut ni2: int = 0
+    while ni2 < len(names):
+        mut nm2: str = names[ni2 + 0]
+        print(f"  Hello, {nm2}!")
+        ni2 += 1
+
+    # While loop when you need full index control:
+    mut i = 0
+    while i < len(scores):
+        print(f"  scores[{i}] = {scores[i + 0]}")
+        i += 1
+
+    # ── 7. enumerate — index + value ──────────────────────────────────────────
+    # Tauraro uses while + manual index for enumerated access:
+    print("=== Enumerate ===")
+    mut fruits: List[str] = ["apple", "banana", "cherry"]
+    mut ei = 0
+    while ei < len(fruits):
+        mut fn: str = fruits[ei + 0]
+        print(f"  [{ei}] {fn}")
+        ei += 1
+
+    # ── 8. List building (comprehension-style) ───────────────────────────────
+    print("=== Comprehension ===")
+    mut numbers: List[int] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+
+    # Transform: square each element
+    mut squares: List[int] = []
+    mut si: int = 0
+    while si < len(numbers):
+        mut sx: int = numbers[si + 0]
+        squares.append(sx * sx)
+        si += 1
+    print(f"squares: first={squares[0]}, last={squares[9]}")   # 1, 100
+
+    # Filter: keep only evens
+    mut evens: List[int] = []
+    mut evi: int = 0
+    while evi < len(numbers):
+        mut ex: int = numbers[evi + 0]
+        if ex % 2 == 0: evens.append(ex)
+        evi += 1
+    print(f"evens len: {len(evens)}")   # 5
+
+    # Transform + filter combined:
+    mut even_squares: List[int] = []
+    mut esi: int = 0
+    while esi < len(numbers):
+        mut esx: int = numbers[esi + 0]
+        if esx % 2 == 0: even_squares.append(esx * esx)
+        esi += 1
+    mut vi: int = 0
+    while vi < len(even_squares):
+        mut vv: int = even_squares[vi + 0]
+        print(f"  {vv}")   # 4 16 36 64 100
+        vi += 1
+
+    # ── 9. Passing lists to functions (borrow — caller keeps ownership) ────────
+    print("=== Functions with Lists ===")
+    mut data: List[int] = [-3, 7, -1, 4, -2, 9, 0]
+    print(f"sum:      {sum_list(data)}")             # 14
+    mut pos = filter_positive(data)
+    print(f"positive: {len(pos)} elements")          # 3 (7, 4, 9)
+    mut rev = reverse_list([1, 2, 3, 4, 5])
+    print(f"reversed[0] = {rev[0]}")                 # 5
+
+    # ── 10. List[str] operations ──────────────────────────────────────────────
+    print("=== List[str] ===")
+    mut tags: List[str] = []
+    tags.append("tauraro")
+    tags.append("systems")
+    tags.append("fast")
+
+    print(f"tags: {len(tags)}")
+    print(f"tags[1] = {tags[1]}")    # systems
+
+    mut ti: int = 0
+    while ti < len(tags):
+        mut tg: str = tags[ti + 0]
+        print(f"  #{tg}")
+        ti += 1
+
+    # ── 11. List[float] ────────────────────────────────────────────────────────
+    print("=== List[float] ===")
+    mut temps: List[float] = [36.6, 37.1, 36.9, 38.2, 37.5]
+    mut sum_f: float = 0.0
+    mut ti2: int = 0
+    while ti2 < len(temps):
+        mut t: float = temps[ti2 + 0]
+        sum_f += t
+        ti2 += 1
+    mut avg: float = sum_f / len(temps) as float
+    print(f"avg temp: {avg}")
+
+    # ── 12. Dict — string-keyed hash map ──────────────────────────────────────
+    print("=== Dict ===")
+    # Create with a literal:
+    mut config: Dict = {"host": "localhost", "port": "8080", "debug": "true"}
+
+    # Read a value:
+    host_val: str = config.get("host")
+    print(f"host: {host_val}")    # localhost
+
+    # Write/update a value:
+    config.set("timeout", "30")
+    config.set("port", "9090")
+
+    # Check if key exists:
+    if config.has("debug"):
+        debug_val: str = config.get("debug")
+        print(f"debug = {debug_val}")    # true
+
+    if not config.has("missing_key"):
+        print("missing_key not present")
+
+    # Empty Dict:
+    mut store: Dict = {}
+    store.set("name", "Tauraro")
+    store.set("version", "2")
+    has_name: bool = store.has("name")
+    print(f"store has name: {has_name}")
+
+    # ── 13. Dict — counting pattern ───────────────────────────────────────────
+    print("=== Dict Counting ===")
+    sentence: str = "the quick brown fox jumps over the lazy dog the"
+    mut word_counts: Dict = {}
+    mut ws: List[str] = sentence.split(" ")
+    mut wi: int = 0
+    while wi < len(ws):
+        mut word: str = ws[wi + 0]
+        if word_counts.has(word):
+            mut wval: str = word_counts.get(word)
+            mut n: int = int(wval)
+            word_counts.set(word, str(n + 1))
+        else:
+            word_counts.set(word, "1")
+        wi += 1
+
+    the_count: str = word_counts.get("the")
+    fox_count: str = word_counts.get("fox")
+    print(f"the appears: {the_count} times")    # 3
+    print(f"fox appears: {fox_count} times")    # 1
+
+    # ── 14. Ownership — lists returned from functions ─────────────────────────
+    # Returning a list transfers ownership to the caller.
+    print("=== Ownership ===")
+    mut my_range = make_range(5)    # my_range owns the returned list
+    print(f"make_range(5): {len(my_range)} elements")
+    print(f"first: {my_range[0]}, last: {my_range[4]}")
+
+    print("=== done ===")

--- a/examples/07_classes.tr
+++ b/examples/07_classes.tr
@@ -1,0 +1,268 @@
+# 07 — Classes and Extend
+# Covers: class (data layout), extend (methods), constructor pattern (init),
+# self, pub visibility, static methods, multiple extend blocks,
+# struct embedding (inheritance), @packed decorator.
+
+# ── 1. Simple class with fields ───────────────────────────────────────────────
+# 'class' declares the data layout only — field names and types.
+# Fields are PRIVATE by default; use 'pub' to expose them.
+class Point:
+    pub x: int
+    pub y: int
+
+# ── 2. Methods via 'extend' ───────────────────────────────────────────────────
+# 'extend' attaches methods to a class. Separating data from methods lets you
+# read the struct layout without scrolling through function bodies.
+extend Point:
+    # Constructor: a static method named 'init' by convention.
+    # 'Point()' allocates a zero-initialised heap instance.
+    pub def init(px: int, py: int) -> Point:
+        mut p = Point()
+        p.x = px
+        p.y = py
+        return p
+
+    # Static method — no 'self'. Called as Point.origin()
+    pub def origin() -> Point:
+        return Point.init(0, 0)
+
+    # Instance method — 'self' is a pointer to the current instance.
+    # 'self.field' compiles to 'self->field' in C.
+    pub def distance_sq(self) -> int:
+        return self.x * self.x + self.y * self.y
+
+    pub def translate(self, dx: int, dy: int) -> void:
+        self.x += dx
+        self.y += dy
+
+    pub def describe(self) -> void:
+        print(f"Point({self.x}, {self.y})")
+
+    # __str__ — used when the object appears in an f-string
+    pub def __str__(self) -> str:
+        return f"({self.x}, {self.y})"
+
+# ── 3. Multiple extend blocks — organise methods by concern ──────────────────
+class Counter:
+    pub value: int
+    step: int       # private — only accessible inside this file
+
+extend Counter:    # construction
+    pub def init(start: int, step: int) -> Counter:
+        mut c = Counter()
+        c.value = start
+        c.step  = step
+        return c
+
+extend Counter:    # mutation
+    pub def increment(self) -> void:
+        self.value += self.step
+
+    pub def reset(self) -> void:
+        self.value = 0
+
+extend Counter:    # querying
+    pub def get(self) -> int:
+        return self.value
+
+    pub def describe(self) -> void:
+        print(f"Counter(value={self.value}, step={self.step})")
+
+# ── 4. Class with various field types ─────────────────────────────────────────
+class Config:
+    pub host:    str
+    pub port:    i32
+    pub timeout: float
+    pub debug:   bool
+    pub tags:    List[str]
+
+extend Config:
+    pub def init(host: str, port: i32) -> Config:
+        mut cfg = Config()
+        cfg.host    = host
+        cfg.port    = port
+        cfg.timeout = 30.0
+        cfg.debug   = false
+        cfg.tags    = []
+        return cfg
+
+    pub def add_tag(self, tag: str) -> void:
+        self.tags.append(tag)
+
+    pub def describe(self) -> void:
+        print(f"Config: {self.host}:{self.port as int}")
+        print(f"  timeout={self.timeout}  debug={self.debug}")
+        print(f"  tags: {len(self.tags)}")
+
+# ── 5. Classes sharing common patterns ───────────────────────────────────────
+# Both Animal and Dog have name/sound fields — demonstrated via composition.
+class Animal:
+    pub name: str
+    pub sound: str
+
+extend Animal:
+    pub def init(name: str, sound: str) -> Animal:
+        mut a = Animal()
+        a.name  = name
+        a.sound = sound
+        return a
+
+    pub def speak(self) -> void:
+        print(f"{self.name} says {self.sound}!")
+
+# Dog has its own name/sound/breed/tricks fields (no embedding needed)
+class Dog:
+    pub name:   str
+    pub sound:  str
+    pub breed:  str
+    pub tricks: int
+
+extend Dog:
+    pub def init(name: str, breed: str) -> Dog:
+        mut d = Dog()
+        d.name   = name
+        d.sound  = "Woof"
+        d.breed  = breed
+        d.tricks = 0
+        return d
+
+    pub def speak(self) -> void:
+        print(f"{self.name} says {self.sound}!")
+
+    pub def learn_trick(self) -> void:
+        self.tricks += 1
+        print(f"{self.name} learned a trick! ({self.tricks} total)")
+
+    pub def describe(self) -> void:
+        print(f"Dog: {self.name} ({self.breed}), {self.tricks} tricks")
+
+# ── 6. @packed — exact byte layout for hardware/network structs ───────────────
+@packed
+class NetworkHeader:
+    pub version: u8
+    pub flags:   u8
+    pub length:  u16
+    pub seq:     u32
+
+extend NetworkHeader:
+    pub def init(ver: u8, len_val: u16, seq_val: u32) -> NetworkHeader:
+        mut h = NetworkHeader()
+        h.version = ver
+        h.flags   = 0 as u8
+        h.length  = len_val
+        h.seq     = seq_val
+        return h
+
+    pub def describe(self) -> void:
+        print(f"Header: ver={self.version as int} len={self.length as int} seq={self.seq as int}")
+
+# ── 7. Inheritance via 'extends' ──────────────────────────────────────────────
+# 'extends' embeds all parent fields into the child struct and enables
+# inherited method dispatch. Use super(ClassName).method() to call the parent.
+class Shape:
+    pub color: str
+
+extend Shape:
+    pub def init(color: str) -> Shape:
+        mut s = Shape()
+        s.color = color
+        return s
+
+    pub def describe(self) -> void:
+        print(f"Shape color={self.color}")
+
+    pub def area(self) -> float:
+        return 0.0
+
+class Circle extends Shape:
+    pub radius: float
+
+extend Circle:
+    pub def init(color: str, radius: float) -> Circle:
+        mut c = Circle()
+        c.color  = color
+        c.radius = radius
+        return c
+
+    pub def area(self) -> float:
+        return 3.14159 * self.radius * self.radius
+
+    pub def describe(self) -> void:
+        super(Shape).describe()
+        print(f"  radius={self.radius} area={self.area()}")
+
+def main():
+
+    # ── Point usage ───────────────────────────────────────────────────────────
+    print("=== Point ===")
+    mut p = Point.init(3, 4)
+    p.describe()                           # Point(3, 4)
+    print(f"distance_sq = {p.distance_sq()}")   # 25
+
+    p.translate(1, -1)
+    p.describe()                           # Point(4, 3)
+
+    # Direct field access (pub fields only):
+    print(f"p.x = {p.x}")
+    p.y = 10
+    print(f"p.y after assign = {p.y}")    # 10
+
+    # Static method:
+    mut origin = Point.origin()
+    origin.describe()    # Point(0, 0)
+
+    # ── Counter with multiple extend blocks ───────────────────────────────────
+    print("=== Counter ===")
+    mut c = Counter.init(0, 5)
+    c.describe()
+    c.increment()
+    c.increment()
+    c.increment()
+    print(f"value: {c.get()}")    # 15
+    c.reset()
+    print(f"after reset: {c.get()}")    # 0
+
+    # ── Config with list field ────────────────────────────────────────────────
+    print("=== Config ===")
+    mut cfg = Config.init("localhost", 8080 as i32)
+    cfg.add_tag("api")
+    cfg.add_tag("v2")
+    cfg.debug = true
+    cfg.describe()
+
+    # ── Dog with its own fields ───────────────────────────────────────────────
+    print("=== Dog ===")
+    mut dog = Dog.init("Rex", "German Shepherd")
+    dog.speak()           # Rex says Woof!
+    dog.learn_trick()     # Rex learned a trick!
+    dog.learn_trick()
+    dog.describe()        # Dog: Rex (German Shepherd), 2 tricks
+
+    mut cat = Animal.init("Whiskers", "Meow")
+    cat.speak()           # Whiskers says Meow!
+
+    # ── @packed header ────────────────────────────────────────────────────────
+    print("=== NetworkHeader (@packed) ===")
+    mut hdr = NetworkHeader.init(1 as u8, 256 as u16, 42 as u32)
+    hdr.describe()
+
+    # ── Immutability rule ─────────────────────────────────────────────────────
+    print("=== Mutability ===")
+    # Without 'mut', fields cannot be assigned:
+    immutable_p = Point.init(1, 2)
+    # immutable_p.x = 5   # ERROR [M-6]: cannot assign field of immutable binding
+
+    mut mutable_p = Point.init(1, 2)
+    mutable_p.x = 5        # OK — binding is mut
+    mutable_p.describe()   # Point(5, 2)
+
+    # ── Inheritance ───────────────────────────────────────────────────────────
+    print("=== Inheritance (extends + super) ===")
+    mut circle = Circle.init("red", 5.0)
+    circle.describe()       # Shape color=red \n   radius=5.0 area=78.5...
+    circle.area()
+
+    mut plain_shape = Shape.init("blue")
+    plain_shape.describe()  # Shape color=blue
+
+    print("=== done ===")

--- a/examples/08_enums.tr
+++ b/examples/08_enums.tr
@@ -1,0 +1,268 @@
+# 08 — Enums (Algebraic Data Types)
+# Covers: simple enums, data-carrying variants, match destructuring,
+# methods on enums, Option[T] pattern, Result[T,E] pattern,
+# enums in lists, expression evaluator example.
+
+# ── 1. Simple enum (no data) ──────────────────────────────────────────────────
+enum Direction:
+    North
+    South
+    East
+    West
+
+# Methods on enums work exactly like methods on classes.
+extend Direction:
+    pub def opposite(self) -> Direction:
+        match self:
+            case Direction.North: return Direction.South
+            case Direction.South: return Direction.North
+            case Direction.East:  return Direction.West
+            case Direction.West:  return Direction.East
+            case _:               return Direction.North
+
+    pub def is_vertical(self) -> bool:
+        match self:
+            case Direction.North: return true
+            case Direction.South: return true
+            case _:               return false
+
+    pub def name(self) -> str:
+        match self:
+            case Direction.North: return "North"
+            case Direction.South: return "South"
+            case Direction.East:  return "East"
+            case Direction.West:  return "West"
+            case _:               return "Unknown"
+
+# ── 2. Data-carrying variants ─────────────────────────────────────────────────
+# Each variant can hold different data. Compiles to a tagged union in C —
+# no heap allocation, no virtual dispatch.
+enum Shape:
+    Circle(radius: float)
+    Rect(width: float, height: float)
+    Triangle(base: float, height: float)
+    Point                                  # no data
+
+extend Shape:
+    pub def area(self) -> float:
+        match self:
+            case Shape.Circle(r):
+                return 3.14159 * r * r
+            case Shape.Rect(w, h):
+                return w * h
+            case Shape.Triangle(b, h):
+                return b * h / 2.0
+            case Shape.Point:
+                return 0.0
+            case _:
+                return 0.0
+
+    pub def perimeter(self) -> float:
+        match self:
+            case Shape.Circle(r):
+                return 2.0 * 3.14159 * r
+            case Shape.Rect(w, h):
+                return 2.0 * (w + h)
+            case Shape.Triangle(b, h):
+                return b + h + b   # simplified
+            case Shape.Point:
+                return 0.0
+            case _:
+                return 0.0
+
+    pub def describe(self) -> void:
+        match self:
+            case Shape.Circle(r):
+                mut ca: float = self.area()
+                print(f"Circle(r={r}): area={ca}")
+            case Shape.Rect(w, h):
+                mut ra: float = self.area()
+                print(f"Rect({w}x{h}): area={ra}")
+            case Shape.Triangle(b, h):
+                mut ta: float = self.area()
+                print(f"Triangle(b={b},h={h}): area={ta}")
+            case Shape.Point:
+                print("Point")
+            case _:
+                pass
+
+# ── 3. Message enum — multiple data types per variant ─────────────────────────
+enum Message:
+    Text(content: str)
+    Image(path: str, width: int, height: int)
+    Error(code: int, msg: str)
+    Close
+
+extend Message:
+    pub def describe(self) -> void:
+        match self:
+            case Message.Text(content):
+                print(f"  text: {content}")
+            case Message.Image(path, w, h):
+                print(f"  image: {path} ({w}x{h})")
+            case Message.Error(code, msg):
+                print(f"  error {code}: {msg}")
+            case Message.Close:
+                print("  connection closed")
+            case _:
+                pass
+
+# ── 4. Enum as expression result ──────────────────────────────────────────────
+enum ParseResult:
+    Ok(value: int)
+    Err(message: str)
+
+def safe_parse(s: str) -> ParseResult:
+    if len(s) == 0:
+        return ParseResult.Err("empty string")
+    mut n = int(s)
+    if n < 0:
+        return ParseResult.Err(f"negative not allowed: {s}")
+    return ParseResult.Ok(n)
+
+# ── 5. State machine via enum ─────────────────────────────────────────────────
+enum TrafficLight:
+    Red
+    Yellow
+    Green
+
+extend TrafficLight:
+    pub def next(self) -> TrafficLight:
+        match self:
+            case TrafficLight.Red:    return TrafficLight.Green
+            case TrafficLight.Green:  return TrafficLight.Yellow
+            case TrafficLight.Yellow: return TrafficLight.Red
+            case _:                   return TrafficLight.Red
+
+    pub def action(self) -> str:
+        match self:
+            case TrafficLight.Red:    return "Stop"
+            case TrafficLight.Yellow: return "Caution"
+            case TrafficLight.Green:  return "Go"
+            case _:                   return "Unknown"
+
+def find_first(items: List[int], target: int) -> Option[int]:
+    mut i = 0
+    while i < len(items):
+        mut cur: int = items[i + 0]
+        if cur == target:
+            return Option.Some(i)
+        i += 1
+    return Option.None
+
+def main():
+
+    # ── Simple enum usage ─────────────────────────────────────────────────────
+    print("=== Direction ===")
+    mut d: Direction = Direction.North
+    print(d.name())                     # North
+    print(d.opposite().name())          # South
+    mut iv1: bool = d.is_vertical()
+    print(f"is_vertical: {iv1}")        # true
+
+    d = Direction.East
+    print(d.name())                     # East
+    mut iv2: bool = d.is_vertical()
+    print(f"is_vertical: {iv2}")        # false
+
+    # ── Data-carrying variants ────────────────────────────────────────────────
+    print("=== Shapes ===")
+    mut circle:   Shape = Shape.Circle(5.0)
+    mut rect:     Shape = Shape.Rect(3.0, 4.0)
+    mut triangle: Shape = Shape.Triangle(6.0, 8.0)
+    mut pt:       Shape = Shape.Point
+
+    circle.describe()     # Circle(r=5.0): area=78.53...
+    rect.describe()       # Rect(3.0x4.0): area=12.0
+    triangle.describe()   # Triangle(b=6.0,h=8.0): area=24.0
+    pt.describe()         # Point
+
+    # Accumulate area without List[Shape] (user-defined enum lists unsupported):
+    mut total_area: float = 0.0
+    total_area += circle.area()
+    total_area += rect.area()
+    total_area += triangle.area()
+    total_area += pt.area()
+    print(f"total area: {total_area}")
+
+    # ── Match with destructuring ──────────────────────────────────────────────
+    print("=== Match Destructuring ===")
+    mut msg1: Message = Message.Text("hello, world")
+    mut msg2: Message = Message.Image("photo.png", 1920, 1080)
+    mut msg3: Message = Message.Error(404, "not found")
+    mut msg4: Message = Message.Close
+    msg1.describe()
+    msg2.describe()
+    msg3.describe()
+    msg4.describe()
+
+    # Destructuring in match arm — fields bound as local immutable variables:
+    match rect:
+        case Shape.Rect(w, h):
+            print(f"rect is {w} wide and {h} tall")
+        case _:
+            pass
+
+    # Wildcard _ to ignore a field:
+    match rect:
+        case Shape.Rect(w, _):
+            print(f"width only: {w}")
+        case _:
+            pass
+
+    # ── ParseResult pattern ───────────────────────────────────────────────────
+    print("=== ParseResult ===")
+    mut inputs: List[str] = []
+    inputs.append("42")
+    inputs.append("-5")
+    inputs.append("")
+    inputs.append("100")
+    mut ii: int = 0
+    while ii < len(inputs):
+        mut inp: str = inputs[ii + 0]
+        match safe_parse(inp):
+            case ParseResult.Ok(v):
+                print(f"  ok: {v}")
+            case ParseResult.Err(e):
+                print(f"  err: {e}")
+            case _:
+                pass
+        ii += 1
+
+    # ── Traffic light state machine ───────────────────────────────────────────
+    print("=== Traffic Light ===")
+    mut light: TrafficLight = TrafficLight.Red
+    mut step: int = 0
+    while step < 6:
+        mut act: str = light.action()
+        print(f"  {act}")
+        light = light.next()
+        step += 1
+
+    # ── Option[T] — built-in optional type ────────────────────────────────────
+    print("=== Option[T] ===")
+    mut data: List[int] = [10, 20, 30, 40, 50]
+    match find_first(data, 30):
+        case Option.Some(idx):
+            print(f"found 30 at index {idx}")    # 2
+        case Option.None:
+            print("not found")
+        case _:
+            pass
+
+    match find_first(data, 99):
+        case Option.Some(idx):
+            print(f"found at {idx}")
+        case Option.None:
+            print("99 not found")    # this prints
+        case _:
+            pass
+
+    # ── Best practice: always include 'case _:' ───────────────────────────────
+    # Even if you think all variants are handled, a future enum change can
+    # add a new variant that silently falls through without the wildcard.
+    match d:
+        case Direction.North: print("north specific logic")
+        case _: pass    # catches East, West, South, and any future variants
+
+    print("=== done ===")

--- a/examples/09_interfaces.tr
+++ b/examples/09_interfaces.tr
@@ -1,0 +1,219 @@
+# 09 — Interfaces
+# Covers: interface declaration, implementing an interface, polymorphic functions,
+# multiple interfaces per class.
+# Interfaces compile to C vtables (fat pointer = data + vtable pointer).
+# Syntax: 'class Dog implements Animal:' — implements goes in the class header.
+
+# ── 1. Declare an interface ───────────────────────────────────────────────────
+interface Animal:
+    def speak(self) -> void
+    def name(self) -> str
+    def legs(self) -> int
+
+# ── 2. Implement the interface on concrete classes ────────────────────────────
+class Dog implements Animal:
+    pub label: str
+    pub breed: str
+
+extend Dog:
+    pub def init(name: str, breed: str) -> Dog:
+        mut d = Dog()
+        d.label = name
+        d.breed = breed
+        return d
+
+    pub def speak(self) -> void:
+        print(f"  {self.label}: Woof!")
+
+    pub def name(self) -> str:
+        return self.label
+
+    pub def legs(self) -> int:
+        return 4
+
+class Cat implements Animal:
+    pub label: str
+
+extend Cat:
+    pub def init(name: str) -> Cat:
+        mut c = Cat()
+        c.label = name
+        return c
+
+    pub def speak(self) -> void:
+        print(f"  {self.label}: Meow!")
+
+    pub def name(self) -> str:
+        return self.label
+
+    pub def legs(self) -> int:
+        return 4
+
+class Bird implements Animal:
+    pub label: str
+    pub can_fly: bool
+
+extend Bird:
+    pub def init(name: str, can_fly: bool) -> Bird:
+        mut b = Bird()
+        b.label   = name
+        b.can_fly = can_fly
+        return b
+
+    pub def speak(self) -> void:
+        print(f"  {self.label}: Tweet!")
+
+    pub def name(self) -> str:
+        return self.label
+
+    pub def legs(self) -> int:
+        return 2
+
+# ── 3. Polymorphic function — accepts any Animal ──────────────────────────────
+def introduce(a: Animal) -> void:
+    print(f"  Name: {a.name()},  Legs: {a.legs()}")
+    a.speak()
+
+def loudest_first(a: Animal, b: Animal) -> void:
+    a.speak()
+    b.speak()
+
+# ── 4. Second interface ───────────────────────────────────────────────────────
+interface Drawable:
+    def draw(self) -> void
+    def bounding_box(self) -> str
+
+class Circle implements Drawable:
+    pub radius: float
+
+extend Circle:
+    pub def init(r: float) -> Circle:
+        mut c = Circle()
+        c.radius = r
+        return c
+
+    pub def area(self) -> float:
+        return 3.14159 * self.radius * self.radius
+
+    pub def draw(self) -> void:
+        print(f"  drawing circle r={self.radius}")
+
+    pub def bounding_box(self) -> str:
+        mut d = self.radius * 2.0
+        return f"{d}x{d}"
+
+class Rect implements Drawable:
+    pub width: float
+    pub height: float
+
+extend Rect:
+    pub def init(w: float, h: float) -> Rect:
+        mut r = Rect()
+        r.width  = w
+        r.height = h
+        return r
+
+    pub def area(self) -> float:
+        return self.width * self.height
+
+    pub def draw(self) -> void:
+        print(f"  drawing rect {self.width}x{self.height}")
+
+    pub def bounding_box(self) -> str:
+        return f"{self.width}x{self.height}"
+
+def render(s: Drawable) -> void:
+    s.draw()
+    print(f"    bbox: {s.bounding_box()}")
+
+# ── 5. Multiple interfaces on one class ──────────────────────────────────────
+interface Printable:
+    def print_info(self) -> void
+
+interface Serializable:
+    def serialize(self) -> str
+
+class Employee implements Printable, Serializable:
+    pub name:   str
+    pub salary: int
+    pub dept:   str
+
+extend Employee:
+    pub def init(name: str, salary: int, dept: str) -> Employee:
+        mut e = Employee()
+        e.name   = name
+        e.salary = salary
+        e.dept   = dept
+        return e
+
+    pub def print_info(self) -> void:
+        print(f"  Employee: {self.name} | dept={self.dept} | salary={self.salary}")
+
+    pub def serialize(self) -> str:
+        return f"{self.name},{self.salary},{self.dept}"
+
+def print_one(item: Printable) -> void:
+    item.print_info()
+
+def serialize_one(item: Serializable) -> str:
+    return item.serialize()
+
+def main():
+
+    # ── Wrapping concrete instances ───────────────────────────────────────────
+    # The compiler auto-generates ClassName_as_InterfaceName() when
+    # 'class Dog implements Animal:' is used.
+    print("=== Animal Interface ===")
+    mut dog1 = Dog.init("Rex", "German Shepherd")
+    mut cat1 = Cat.init("Whiskers")
+    mut bird = Bird.init("Tweety", true)
+
+    mut a_dog: Animal = Dog_as_Animal(dog1)
+    mut a_cat: Animal = Cat_as_Animal(cat1)
+    mut a_bird: Animal = Bird_as_Animal(bird)
+
+    introduce(a_dog)
+    introduce(a_cat)
+    introduce(a_bird)
+
+    # Direct dispatch through interface value:
+    print("=== Direct Dispatch ===")
+    a_dog.speak()
+    a_cat.speak()
+    a_bird.speak()
+
+    print(f"  Rex has {a_dog.legs()} legs")
+    print(f"  Tweety name: {a_bird.name()}")
+
+    loudest_first(a_dog, a_cat)
+
+    # ── Drawable interface ────────────────────────────────────────────────────
+    print("=== Drawable Interface ===")
+    mut c = Circle.init(5.0)
+    mut r = Rect.init(3.0, 4.0)
+
+    render(Circle_as_Drawable(c))
+    render(Rect_as_Drawable(r))
+
+    # ── Multiple interfaces ────────────────────────────────────────────────────
+    print("=== Multiple Interfaces ===")
+    mut e1 = Employee.init("Alice", 95000, "Engineering")
+    mut e2 = Employee.init("Bob",   72000, "Sales")
+    mut e3 = Employee.init("Carol", 88000, "Design")
+
+    # Use via Printable interface:
+    print_one(Employee_as_Printable(e1))
+    print_one(Employee_as_Printable(e2))
+    print_one(Employee_as_Printable(e3))
+
+    # Use via Serializable interface:
+    mut serialized = serialize_one(Employee_as_Serializable(e1))
+    print(f"serialized: {serialized}")
+
+    # ── Lifetime note ─────────────────────────────────────────────────────────
+    # IMPORTANT: The concrete instance (dog1, cat1, etc.) must OUTLIVE the
+    # interface value that wraps it. The interface holds a raw pointer —
+    # the compiler does not track this relationship for you.
+    # In the examples above this is safe because both live in main().
+
+    print("=== done ===")

--- a/examples/10_generics.tr
+++ b/examples/10_generics.tr
@@ -1,0 +1,216 @@
+# 10 — Generics and Polymorphism
+# Covers: built-in generic containers (List[T], Dict), type-specific functions,
+# polymorphism via interfaces (cross-reference with 09_interfaces.tr),
+# and the Stack/Queue data structure patterns.
+#
+# Note: Tauraro's user-defined generic functions use void* internally.
+# The language provides generics primarily through built-in types (List[T], Dict)
+# and monomorphized standard-library classes (Vec[T], Map[K,V]).
+#
+# For truly generic algorithms, define type-specific overloads.
+
+# ── 1. Type-specific overloaded functions ─────────────────────────────────────
+def clamp_int(v: int, lo: int, hi: int) -> int:
+    if v < lo: return lo
+    if v > hi: return hi
+    return v
+
+def clamp_float(v: float, lo: float, hi: float) -> float:
+    if v < lo: return lo
+    if v > hi: return hi
+    return v
+
+def first_int(items: List[int]) -> int:
+    return items[0]
+
+def last_int(items: List[int]) -> int:
+    return items[len(items) - 1]
+
+def first_str(items: List[str]) -> str:
+    return items[0]
+
+# ── 2. Stack[int] — type-specific stack ──────────────────────────────────────
+class IntStack:
+    pub items: List[int]
+    pub size:  int
+
+extend IntStack:
+    pub def init() -> IntStack:
+        mut s = IntStack()
+        s.items = []
+        s.size  = 0
+        return s
+
+    pub def push(self, val: int) -> void:
+        self.items.append(val)
+        self.size += 1
+
+    pub def pop(self) -> int:
+        if self.size == 0: raise("pop from empty stack")
+        mut idx = self.size - 1
+        mut val = self.items[idx + 0]
+        self.size -= 1
+        return val
+
+    pub def peek(self) -> int:
+        if self.size == 0: raise("peek at empty stack")
+        mut pidx = self.size - 1
+        return self.items[pidx + 0]
+
+    pub def is_empty(self) -> bool:
+        return self.size == 0
+
+    pub def describe(self) -> void:
+        print(f"IntStack(size={self.size})")
+
+# ── 3. Stack[str] — same pattern for strings ────────────────────────────────
+class StrStack:
+    pub items: List[str]
+    pub size:  int
+
+extend StrStack:
+    pub def init() -> StrStack:
+        mut s = StrStack()
+        s.items = []
+        s.size  = 0
+        return s
+
+    pub def push(self, val: str) -> void:
+        self.items.append(val)
+        self.size += 1
+
+    pub def pop(self) -> str:
+        if self.size == 0: raise("pop from empty stack")
+        mut idx = self.size - 1
+        mut val = self.items[idx + 0]
+        self.size -= 1
+        return val
+
+    pub def peek(self) -> str:
+        if self.size == 0: raise("peek at empty stack")
+        mut pidx = self.size - 1
+        return self.items[pidx + 0]
+
+    pub def is_empty(self) -> bool:
+        return self.size == 0
+
+# ── 4. Pair wrapper ───────────────────────────────────────────────────────────
+class IntStrPair:
+    pub first:  int
+    pub second: str
+
+extend IntStrPair:
+    pub def init(a: int, b: str) -> IntStrPair:
+        mut p = IntStrPair()
+        p.first  = a
+        p.second = b
+        return p
+
+# ── 5. Generic sum using for-loop (works with any numeric List) ───────────────
+def sum_ints(items: List[int]) -> int:
+    mut total = 0
+    for x in items:
+        total += x
+    return total
+
+def sum_floats(items: List[float]) -> float:
+    mut total: float = 0.0
+    for x in items:
+        total += x
+    return total
+
+def concat_strs(items: List[str]) -> str:
+    mut result = ""
+    for s in items:
+        result = result + s
+    return result
+
+def main():
+
+    # ── Type-specific functions ───────────────────────────────────────────────
+    print("=== Type-specific functions ===")
+    print(f"clamp_int(5, 0, 10)  = {clamp_int(5, 0, 10)}")    # 5
+    print(f"clamp_int(-3, 0, 10) = {clamp_int(-3, 0, 10)}")   # 0
+    print(f"clamp_int(15, 0, 10) = {clamp_int(15, 0, 10)}")   # 10
+
+    print(f"clamp_float(1.5, 0.0, 3.0) = {clamp_float(1.5, 0.0, 3.0)}")
+    print(f"clamp_float(5.0, 0.0, 3.0) = {clamp_float(5.0, 0.0, 3.0)}")
+
+    nums = [10, 20, 30, 40, 50]
+    strs = ["alpha", "beta", "gamma"]
+
+    print(f"first_int(nums) = {first_int(nums)}")   # 10
+    print(f"last_int(nums)  = {last_int(nums)}")    # 50
+    print(f"first_str(strs) = {first_str(strs)}")   # alpha
+
+    # ── List[T] — built-in generic container ─────────────────────────────────
+    print("=== List[T] polymorphism ===")
+    mut int_list: List[int]   = [1, 2, 3, 4, 5]
+    mut str_list: List[str]   = ["a", "b", "c"]
+    mut f_list:   List[float] = [1.1, 2.2, 3.3]
+    mut bool_list: List[bool] = [true, false, true]
+
+    print(f"int_list len:  {len(int_list)}")
+    print(f"str_list[1]:   {str_list[1]}")
+    print(f"f_list[2]:     {f_list[2]}")
+    print(f"bool_list[0]:  {bool_list[0]}")
+
+    # ── IntStack ──────────────────────────────────────────────────────────────
+    print("=== IntStack ===")
+    mut int_stack = IntStack.init()
+    int_stack.push(1)
+    int_stack.push(2)
+    int_stack.push(3)
+    int_stack.describe()                       # IntStack(size=3)
+    print(f"peek: {int_stack.peek()}")         # 3
+
+    while not int_stack.is_empty():
+        mut v = int_stack.pop()
+        print(f"  pop: {v}")     # 3 2 1
+
+    # ── StrStack ──────────────────────────────────────────────────────────────
+    print("=== StrStack ===")
+    mut str_stack = StrStack.init()
+    str_stack.push("hello")
+    str_stack.push("world")
+    str_stack.push("tauraro")
+    mut stop = str_stack.peek()
+    print(f"top: {stop}")          # tauraro
+    mut spop1 = str_stack.pop()
+    print(f"pop: {spop1}")         # tauraro
+    mut spop2 = str_stack.pop()
+    print(f"pop: {spop2}")         # world
+
+    # ── IntStrPair ────────────────────────────────────────────────────────────
+    print("=== Pair ===")
+    mut p1 = IntStrPair.init(42, "answer")
+    print(f"p1: ({p1.first}, {p1.second})")   # (42, answer)
+
+    # ── Sum functions ─────────────────────────────────────────────────────────
+    print("=== Sum functions ===")
+    ints   = [1, 2, 3, 4, 5]
+    floats = [1.1, 2.2, 3.3]
+    words  = ["Hello", ", ", "World", "!"]
+
+    print(f"sum ints:   {sum_ints(ints)}")       # 15
+    print(f"sum floats: {sum_floats(floats)}")   # 6.6
+    print(f"concat strs: {concat_strs(words)}")  # Hello, World!
+
+    # ── Dict — generic string-keyed map ──────────────────────────────────────
+    print("=== Dict ===")
+    mut counts: Dict = {}
+    counts.set("apples", "5")
+    counts.set("oranges", "3")
+    counts.set("bananas", "7")
+
+    mut k_apples  = "apples"
+    mut k_oranges = "oranges"
+    mut k_bananas = "bananas"
+    mut apples_val:  str  = counts.get(k_apples)
+    mut oranges_val: str  = counts.get(k_oranges)
+    mut has_ban:     bool = counts.has(k_bananas)
+    print(f"apples:  {apples_val}")
+    print(f"oranges: {oranges_val}")
+    print(f"has bananas: {has_ban}")
+
+    print("=== done ===")

--- a/examples/11_error_handling.tr
+++ b/examples/11_error_handling.tr
@@ -1,0 +1,186 @@
+# 11 — Error Handling
+# Covers: try/except/finally, raise, throws + ?, Result[T,E] inspection,
+# custom error types, mixing both models.
+
+# ── Model 1: throws + ? (zero-overhead, explicit in signature) ────────────────
+
+# 'throws ErrorType' changes the return type to Result[ReturnType, ErrorType].
+# 'return value'  → wraps as Ok  (is_err=false, data.value=value)
+# 'raise(err)'    → wraps as Err (is_err=true,  data.error=err) and returns
+def parse_int_safe(s: str) throws str -> int:
+    if len(s) == 0:
+        raise("empty string")
+    mut i = 0
+    mut result = 0
+    while i < len(s):
+        mut code = ord(s[i + 0])
+        if code < 48 or code > 57:
+            raise(f"not a digit at position {i}: '{s[i + 0]}'")
+        result = result * 10 + (code - 48)
+        i += 1
+    return result
+
+def doubled(s: str) throws str -> int:
+    mut n = parse_int_safe(s)?   # ? = unwrap Ok or propagate Err immediately
+    return n * 2
+
+def quadrupled(s: str) throws str -> int:
+    mut n = doubled(s)?          # chain propagation up
+    return n * 2
+
+# Throws with a richer error type:
+class ParseError:
+    pub message:  str
+    pub position: int
+
+extend ParseError:
+    pub def init(msg: str, pos: int) -> ParseError:
+        mut e = ParseError()
+        e.message  = msg
+        e.position = pos
+        return e
+
+    pub def describe(self) -> void:
+        print(f"  ParseError at pos {self.position}: {self.message}")
+
+def parse_strict(s: str) throws ParseError -> int:
+    if len(s) == 0:
+        raise(ParseError.init("empty input", 0))
+    mut i = 0
+    while i < len(s):
+        if ord(s[i + 0]) < 48 or ord(s[i + 0]) > 57:
+            raise(ParseError.init(f"unexpected char '{s[i + 0]}'", i))
+        i += 1
+    return int(s)
+
+# ── Model 2: try / except / finally (setjmp-based, for boundaries) ────────────
+
+def risky_divide(a: int, b: int) -> int:
+    if b == 0:
+        raise("division by zero")
+    return a / b
+
+# ── Deep chain helpers (must be top-level for forward declarations) ───────────
+def level3(s: str) throws str -> int:
+    return parse_int_safe(s)?
+
+def level2(s: str) throws str -> int:
+    return level3(s)?
+
+def level1(s: str) throws str -> int:
+    return level2(s)?
+
+def main():
+
+    # ── throws: call without ? → get a Result[T,E] ────────────────────────────
+    print("=== throws without ? ===")
+    mut r1: Result[int, str] = parse_int_safe("42")
+    if r1.is_ok:
+        print(f"parsed: {r1.ok}")     # 42
+
+    mut r2: Result[int, str] = parse_int_safe("abc")
+    if r2.is_err:
+        print(f"error: {r2.err}")     # not a digit at position 0
+
+    mut r3: Result[int, str] = parse_int_safe("")
+    if r3.is_err:
+        print(f"error: {r3.err}")     # empty string
+
+    mut r4: Result[int, str] = parse_int_safe("100")
+    print(f"r4.is_ok={r4.is_ok}  value={r4.ok}")
+
+    # ── throws: ? propagation chain ──────────────────────────────────────────
+    print("=== ? propagation ===")
+    mut d1: Result[int, str] = doubled("7")
+    if d1.is_ok:
+        print(f"doubled(7) = {d1.ok}")     # 14
+
+    mut d2: Result[int, str] = doubled("xyz")
+    if d2.is_err:
+        print(f"doubled error: {d2.err}")
+
+    mut q1: Result[int, str] = quadrupled("3")
+    if q1.is_ok:
+        print(f"quadrupled(3) = {q1.ok}")   # 12
+
+    mut q2: Result[int, str] = quadrupled("bad")
+    if q2.is_err:
+        print(f"quadrupled error: {q2.err}")
+
+    # ── Custom error type ─────────────────────────────────────────────────────
+    print("=== Custom Error Type ===")
+    mut ps1: Result[int, ParseError] = parse_strict("123")
+    if ps1.is_ok:
+        print(f"strict parsed: {ps1.ok}")     # 123
+
+    mut ps2: Result[int, ParseError] = parse_strict("12x4")
+    if ps2.is_err:
+        ps2.err.describe()    # ParseError at pos 2: unexpected char 'x'
+
+    # ── try / except ─────────────────────────────────────────────────────────
+    print("=== try / except ===")
+    try:
+        mut result = risky_divide(10, 2)
+        print(f"10 / 2 = {result}")    # 5
+    except e:
+        print(f"caught: {e}")
+
+    try:
+        mut result = risky_divide(10, 0)
+        print(f"result = {result}")   # never reached
+    except e:
+        print(f"caught: {e}")         # caught: division by zero
+
+    # ── try / except / finally ────────────────────────────────────────────────
+    # 'finally' always runs — whether or not an exception was raised.
+    print("=== try / except / finally ===")
+    try:
+        print("  try: doing work")
+        raise("something went wrong")
+        print("  try: after raise")   # never reached
+    except e:
+        print(f"  except: caught '{e}'")
+    finally:
+        print("  finally: always runs")
+
+    print("after try block")   # execution continues here
+
+    # ── try / finally (no except) ─────────────────────────────────────────────
+    try:
+        print("  working...")
+    finally:
+        print("  cleanup (always)")   # runs even without an exception
+
+    # ── Nested try ────────────────────────────────────────────────────────────
+    print("=== Nested try ===")
+    try:
+        try:
+            raise("inner error")
+        except e:
+            print(f"  inner caught: {e}")
+            raise("outer error propagated from inner")
+    except e:
+        print(f"  outer caught: {e}")
+
+    # ── Mixing models: call throws inside try ──────────────────────────────────
+    # The two models interoperate freely.
+    print("=== Mixed models ===")
+    try:
+        mut r: Result[int, str] = parse_int_safe("hello")
+        if r.is_err:
+            raise(r.err)    # convert Result error into exception
+        print(f"value: {r.ok}")
+    except e:
+        print(f"converted to exception: {e}")
+
+    # ── throws across a deep call chain, caught at main ───────────────────────
+    print("=== Deep chain ===")
+    mut chain_r: Result[int, str] = level1("999")
+    if chain_r.is_ok:
+        print(f"chain result: {chain_r.ok}")    # 999
+
+    mut chain_e: Result[int, str] = level1("bad")
+    if chain_e.is_err:
+        print(f"chain error: {chain_e.err}")
+
+    print("=== done ===")

--- a/examples/12_memory_and_ownership.tr
+++ b/examples/12_memory_and_ownership.tr
@@ -1,0 +1,171 @@
+# 12 — Memory and Ownership
+# Covers: automatic ownership (Own/Borrow/Move), immutability default,
+# shared reference counting, none requires pointer type.
+# The compiler inserts every free() — you never write one.
+
+class Point:
+    pub x: int
+    pub y: int
+
+extend Point:
+    pub def init(x: int, y: int) -> Point:
+        mut p = Point()
+        p.x = x
+        p.y = y
+        return p
+
+    pub def describe(self) -> void:
+        print(f"  Point({self.x}, {self.y})")
+
+class Counter:
+    pub value: int
+
+extend Counter:
+    pub def init(start: int) -> Counter:
+        mut c = Counter()
+        c.value = start
+        return c
+
+    pub def increment(self) -> void:
+        self.value += 1
+
+    pub def get(self) -> int:
+        return self.value
+
+# ── Function showing conditional ownership transfer ───────────────────────────
+def make_or_default(use_real: bool) -> Point:
+    if use_real:
+        mut p2 = Point.init(99, 88)
+        return p2              # ownership transferred to caller
+    return Point.init(0, 0)    # new object, also transferred
+
+# ── Functions that borrow (don't take ownership) ──────────────────────────────
+# Class parameters are passed by pointer (borrow). The caller still owns them.
+def describe_point(p: Point) -> void:
+    p.describe()          # reads p but does not consume it
+    # no free injected here — caller owns p
+
+def sum_list(items: List[int]) -> int:
+    mut total = 0
+    for x in items:
+        total += x
+    return total    # no free — caller owns items
+
+# ── Functions that return ownership ───────────────────────────────────────────
+# When a function returns a heap object, ownership transfers to the caller.
+def make_point(x: int, y: int) -> Point:
+    return Point.init(x, y)    # ownership transferred to caller
+
+def make_list(n: int) -> List[int]:
+    mut result: List[int] = []
+    for i in range(n):
+        result.append(i * i)
+    return result    # caller owns this list — no free injected here
+
+def main():
+
+    # ── Rule M-1: Automatic ownership inference ────────────────────────────────
+    # Every heap allocation is marked 'Own'. free() is injected at scope exit.
+    print("=== Own — auto free at scope exit ===")
+    mut p = Point.init(3, 4)   # Own: p owns this heap Point
+    p.describe()
+    # Scope ends → compiler injects: if (p) free(p);
+    # You never write free(p).
+
+    # ── Borrow — passing to a function ────────────────────────────────────────
+    # Passing a class to a function is a BORROW — function gets a pointer,
+    # caller retains ownership.
+    print("=== Borrow ===")
+    mut pt = Point.init(10, 20)
+    describe_point(pt)     # borrow — pt still valid
+    describe_point(pt)     # borrow again — still valid
+    print(f"  pt.x still accessible: {pt.x}")   # 10
+    # Scope ends → free(pt) injected once
+
+    # ── Returning ownership ───────────────────────────────────────────────────
+    print("=== Return ownership ===")
+    mut new_pt = make_point(5, 6)   # owns the returned Point
+    new_pt.describe()
+    # Scope ends → free(new_pt)
+
+    mut my_list = make_list(5)      # owns the returned List
+    print(f"  list len: {len(my_list)}")
+    mut idx3: int = 3
+    print(f"  list[3]:  {my_list[idx3 + 0]}")   # 9 (3²)
+    # Scope ends → List_i64_free(my_list)
+
+    # ── Rule M-6: Immutable by default ────────────────────────────────────────
+    print("=== Immutable by default ===")
+    immutable_point = Point.init(1, 2)
+    # immutable_point.x = 5   # ERROR [M-6]: cannot assign to immutable binding
+    # immutable_point = Point.init(3, 4)  # ERROR: same
+
+    mut mutable_point = Point.init(1, 2)
+    mutable_point.x = 5         # OK — declared with 'mut'
+    mutable_point.describe()    # Point(5, 2)
+
+    # ── Rule M-7: none only for Option[T] ─────────────────────────────────────
+    # Use Option[T] for optional values — Option.None is the null constructor.
+    print("=== none / Option ===")
+    mut opt_str: Option[str] = Option.None
+    match opt_str:
+        case Option.None: print("  opt_str is none")
+        case Option.Some(v): print("  opt_str has some value")
+
+    opt_str = Option.Some("assigned")
+    match opt_str:
+        case Option.Some(v): print("  opt_str: assigned")
+        case Option.None: pass
+
+    # mut bad: int = none   # ERROR [M-7]: int is a value type, not optional
+    # mut bad: bool = none  # ERROR [M-7]: same
+
+    # ── Ownership through multiple borrows ────────────────────────────────────
+    print("=== Multiple borrows ===")
+    mut items: List[int] = [1, 2, 3, 4, 5]
+    print(f"  sum: {sum_list(items)}")       # 15 — borrow
+    print(f"  sum: {sum_list(items)}")       # 15 — borrow again
+    mut first_item = items[0]
+    print(f"  items[0]: {first_item}")       # 1  — still owned
+
+    # ── Ownership and branching ────────────────────────────────────────────────
+    # The compiler injects free() on EVERY exit path — never twice.
+    print("=== Conditional ownership ===")
+    mut real_pt = make_or_default(true)
+    real_pt.describe()     # Point(99, 88)
+
+    mut def_pt = make_or_default(false)
+    def_pt.describe()      # Point(0, 0)
+
+    # ── shared — reference-counted ownership ──────────────────────────────────
+    # 'shared' wraps a value in an atomic reference-counted box.
+    # Use when multiple owners need access to the same instance.
+    print("=== shared ===")
+    mut c = Counter.init(0)
+    shared s1 = c        # ref count = 1; s1 points to the same Counter
+    shared s2 = s1       # ref count = 2; s1 and s2 share one Counter
+
+    s1.increment()
+    s2.increment()
+    s1.increment()
+
+    print(f"  s1.get() = {s1.get()}")   # 3 (both accessed same Counter)
+    print(f"  s2.get() = {s2.get()}")   # 3
+
+    # When s2 goes out of scope → ref count drops to 1
+    # When s1 goes out of scope → ref count drops to 0 → Counter freed
+    # You never write free() for shared values either.
+
+    # ── String ownership ──────────────────────────────────────────────────────
+    # String literals → read-only data segment, never freed.
+    # Dynamic strings (f-strings, concatenation) → heap, freed at scope exit.
+    print("=== String ownership ===")
+    literal = "static string"   # not heap — never freed
+    mut dyn  = f"dynamic: {literal}"   # heap allocated — freed at scope exit
+    mut concat = "hello" + " " + "world"  # heap — freed at scope exit
+
+    print(literal)
+    print(dyn)
+    print(concat)
+
+    print("=== done ===")

--- a/examples/13_unsafe_and_pointers.tr
+++ b/examples/13_unsafe_and_pointers.tr
@@ -1,0 +1,166 @@
+# 13 — Unsafe Blocks and Raw Pointers
+# Covers: unsafe: block, Pointer[T], &address, read/write/offset,
+# alloc[T]/dealloc, sizeof, Pointer[void] casting, asm().
+# unsafe: is for containment — it makes low-level operations visible
+# and auditable without forbidding them.
+
+# ── Safe buffer wrapper class (must be at top-level) ──────────────────────────
+# Put raw pointer operations inside a class with a safe public API.
+# Callers see only the safe interface; unsafe: is invisible to them.
+class IntBuf:
+    pub ptr:  Pointer[int]
+    pub size: int
+
+extend IntBuf:
+    pub def init(n: int) -> IntBuf:
+        mut b = IntBuf()
+        b.size = n
+        unsafe:
+            b.ptr = alloc[int](n)
+        return b
+
+    pub def get(self, i: int) -> int:
+        if i < 0 or i >= self.size: raise("index out of bounds")
+        unsafe:
+            return self.ptr.offset(i).read()
+
+    pub def set(self, i: int, v: int) -> void:
+        if i < 0 or i >= self.size: raise("index out of bounds")
+        unsafe:
+            self.ptr.offset(i).write(v)
+
+    pub def drop(self) -> void:
+        unsafe:
+            dealloc(self.ptr)
+
+def main():
+
+    # ── 1. Basic unsafe: block ────────────────────────────────────────────────
+    # Pointer[T] is a raw C pointer (T*). The compiler does NOT track its
+    # lifetime or inject free() for it.
+    print("=== Basic Pointer ===")
+    mut x: int = 42
+    mut y: int = 0
+
+    unsafe:
+        mut p: Pointer[int] = &x    # take address of x → int*
+        y = p.read()                 # dereference: y = *p = 42
+        p.write(100)                 # *p = 100  →  x is now 100
+
+    print(f"y = {y}")    # 42
+    print(f"x = {x}")    # 100 (modified through pointer)
+
+    # ── 2. Pointer arithmetic: offset ────────────────────────────────────────
+    # offset(n) advances by n * sizeof(T) bytes — same as C pointer arithmetic.
+    print("=== Pointer Arithmetic ===")
+    mut arr_a: int = 10
+
+    unsafe:
+        mut base: Pointer[int] = &arr_a
+        print(f"base.read() = {base.read()}")              # 10
+
+    # ── 3. Manual heap allocation ─────────────────────────────────────────────
+    # alloc[T](n) allocates n elements of type T, zero-initialised.
+    # dealloc(ptr) frees the allocation.
+    # YOU are responsible for calling dealloc — the compiler will NOT.
+    print("=== alloc / dealloc ===")
+    unsafe:
+        mut buf: Pointer[int] = alloc[int](8)    # 8 ints, zero-initialized
+
+        # Write values:
+        mut i = 0
+        while i < 8:
+            buf.offset(i).write(i * 10)
+            i += 1
+
+        # Read values:
+        mut j = 0
+        while j < 8:
+            print(f"  buf[{j}] = {buf.offset(j).read()}")   # 0 10 20 ... 70
+            j += 1
+
+        dealloc(buf)    # MUST free — compiler will not do this for Pointer[T]
+
+    # ── 4. sizeof — size of a type in bytes ──────────────────────────────────
+    print("=== sizeof ===")
+    print(f"sizeof(int)         = {sizeof(int)}")          # 8
+    print(f"sizeof(float)       = {sizeof(float)}")        # 8
+    print(f"sizeof(bool)        = {sizeof(bool)}")         # 1
+    print(f"sizeof(char)        = {sizeof(char)}")         # 1
+    print(f"sizeof(i32)         = {sizeof(i32)}")          # 4
+    print(f"sizeof(u8)          = {sizeof(u8)}")           # 1
+    print(f"sizeof(Pointer[int]) = {sizeof(Pointer[int])}")  # 8 (64-bit)
+
+    # ── 5. Pointer casts ──────────────────────────────────────────────────────
+    print("=== Pointer Casts ===")
+    mut val: int = 255
+
+    unsafe:
+        # int* → void* (type erasure, common in C APIs)
+        mut val_p: Pointer[int] = &val
+        mut vp: Pointer[void] = val_p as Pointer[void]
+
+        # void* → int* (restore type)
+        mut tp: Pointer[int] = vp as Pointer[int]
+        print(f"through void*: {tp.read()}")    # 255
+
+        # Pointer → integer address (for printing or arithmetic)
+        mut addr: usize = tp as usize
+        print(f"address (usize): {addr}")
+
+        # Integer → pointer (dangerous — only when you know the address is valid)
+        mut rp: Pointer[int] = addr as Pointer[int]
+        print(f"from address: {rp.read()}")    # 255
+
+    # ── 6. Null pointer pattern ───────────────────────────────────────────────
+    print("=== Null Pointer ===")
+    mut maybe: Pointer[int] = 0 as Pointer[int]    # null pointer via cast
+
+    unsafe:
+        if maybe as usize == 0 as usize:
+            print("pointer is null — skipping dereference")
+        else:
+            print(f"value: {maybe.read()}")
+
+    # ── 7. Safe Buffer Wrapper ────────────────────────────────────────────────
+    print("=== Safe Buffer Wrapper ===")
+    mut buf2 = IntBuf.init(5)
+    buf2.set(0, 100)
+    buf2.set(1, 200)
+    buf2.set(2, 300)
+    buf2.set(3, 400)
+    buf2.set(4, 500)
+
+    mut k = 0
+    while k < buf2.size:
+        print(f"  buf[{k}] = {buf2.get(k)}")
+        k += 1
+
+    buf2.drop()    # explicit destructor — frees the raw allocation
+
+    # ── 8. Pointer[void] for C-style type-erased APIs ─────────────────────────
+    print("=== Pointer[void] ===")
+    mut data: int = 42
+
+    unsafe:
+        # Store as void* (type-erased), retrieve later
+        mut data_p: Pointer[int] = &data
+        mut erased: Pointer[void] = data_p as Pointer[void]
+        mut restored: Pointer[int] = erased as Pointer[int]
+        print(f"restored: {restored.read()}")    # 42
+
+    # ── 9. Inline assembly ────────────────────────────────────────────────────
+    # asm() emits raw assembly inside unsafe:. Use only for hardware-specific
+    # operations where no Tauraro/C equivalent exists.
+    print("=== Inline ASM ===")
+    unsafe:
+        asm("nop")       # no-op instruction — does nothing, demonstrates syntax
+        asm("nop")
+        print("  asm(nop) executed")
+
+    # Memory barrier — prevent compiler from reordering across this point:
+    unsafe:
+        asm("", "", "", "memory")
+        print("  memory barrier emitted")
+
+    print("=== done ===")

--- a/examples/14_modules.tr
+++ b/examples/14_modules.tr
@@ -1,0 +1,155 @@
+# 14 — Modules
+# Covers: import syntax, from...import, aliases, pub visibility, export.
+#
+# A module = a .tr source file. Every file is a module.
+# Module name = file path relative to project root, dots replace slashes.
+#
+# This file demonstrates module SYNTAX and concepts in a single file.
+# For a real multi-file demo see the layout comments below.
+
+# ── Import syntax reference (these would live in a real project) ──────────────
+#
+# ❶ Plain import — access via qualified name:
+#     import math.geometry
+#     mut area = math.geometry.circle_area(5.0)
+#
+# ❷ Import with alias:
+#     import math.geometry as geo
+#     mut area = geo.circle_area(5.0)
+#
+# ❸ Selective import — names land directly in current scope:
+#     from math.geometry import circle_area, rect_area
+#     mut area = circle_area(5.0)
+#
+# ❹ Selective import with alias:
+#     from math.geometry import circle_area as area
+#     from core.string import StringBuilder as SB
+#
+# ❺ Module resolved from file system:
+#     "math/geometry.tr"    → import as: math.geometry
+#     "math/geometry/mod.tr" → import as: math.geometry  (mod.tr convention)
+
+# ── Visibility: pub controls what other modules can use ───────────────────────
+#
+# By default everything is PRIVATE — visible only inside this file.
+# Use 'pub' to expose to other modules.
+
+# Private — only this file can call it:
+def _internal_helper(x: int) -> int:
+    return x * 2
+
+# Public — importable from other modules:
+pub def public_add(a: int, b: int) -> int:
+    return a + b
+
+# Public class — all fields and methods need 'pub' individually:
+pub class MathUtils:
+    pub precision: int    # public field
+    scale: int            # private field — not accessible from other modules
+
+extend MathUtils:
+    pub def init(precision: int) -> MathUtils:
+        mut m = MathUtils()
+        m.precision = precision
+        m.scale     = 10    # private — only set internally
+        return m
+
+    pub def square(self, x: float) -> float:      # public method
+        return x * x
+
+    def _scale_up(self, x: float) -> float:       # private method
+        return x * self.scale as float
+
+# ── export — stable C symbol for FFI / shared library ────────────────────────
+#
+# Without 'export': function 'add' in module 'utils' → C symbol 'utils_add'
+# With    'export': → C symbol 'add' (no prefix, stable across refactors)
+
+pub def add(a: int, b: int) -> int:
+    return a + b
+
+pub def tauraro_version() -> str:
+    return "2.0"
+
+# ── mod.tr — re-export hub for a directory of modules ────────────────────────
+#
+# If you have:
+#   math/vec2.tr
+#   math/matrix.tr
+#   math/mod.tr          ← re-exports both
+#
+# math/mod.tr contains:
+#   from math.vec2   import Vec2
+#   from math.matrix import Matrix4
+#
+# Then callers can write:
+#   from math import Vec2, Matrix4
+# Instead of importing each sub-module separately.
+
+# ── Project layout examples ───────────────────────────────────────────────────
+#
+# Small project:
+#   main.tr          ← entry point
+#   utils.tr         ← helper functions
+#   types.tr         ← shared data types
+#
+# Medium project:
+#   main.tr
+#   config.tr
+#   math/
+#     vec2.tr        ← import as: math.vec2
+#     matrix.tr      ← import as: math.matrix
+#   network/
+#     http.tr        ← import as: network.http
+#     tcp.tr         ← import as: network.tcp
+#     mod.tr         ← re-exports: from network import Http, Tcp
+#
+# Tauraro standard library:
+#   from std.core.vec   import Vec
+#   from std.core.map   import Map
+#   from std.core.io    import File
+
+# ── Symbol naming in generated C ──────────────────────────────────────────────
+#
+# math.geometry.circle_area  →  math_geometry_circle_area  in C
+# core.string.to_upper       →  core_string_to_upper       in C
+# main.process               →  process                    (no prefix for main)
+#
+# Don't hardcode C symbol names — module refactors change them.
+# Use 'export' for names that must be stable.
+
+# ── Circular imports are not allowed ─────────────────────────────────────────
+#
+# If module A imports B, and B imports A → compile error:
+#   ERROR: circular import: main → utils → main
+#
+# Fix: extract the shared types into a third module that both import.
+
+def main():
+    print("=== Module Concepts ===")
+
+    # Within this single file, we can use all declarations directly:
+    print(f"public_add(3, 4)    = {public_add(3, 4)}")       # 7
+    print(f"_internal_helper(5) = {_internal_helper(5)}")    # 10 (private, same file)
+
+    mut m = MathUtils.init(6)
+    print(f"square(4.0)  = {m.square(4.0)}")                 # 16.0
+    print(f"precision    = {m.precision}")                   # 6
+    # print(m.scale)  # ERROR if this were another module — field is private
+
+    print(f"add(10, 20)          = {add(10, 20)}")           # 30 (exported)
+    print(f"tauraro_version()    = {tauraro_version()}")     # 2.0
+
+    # ── Demonstrate import path resolution ───────────────────────────────────
+    # The compiler searches for modules in this order:
+    #   1. current working directory
+    #   2. directory of the main source file
+    #   3. std/   (if exists)
+    #   4. stdlib/ (if exists)
+    #   5. paths from -I <dir> flags
+    #
+    # Standard library:
+    #   from std.core.vec import Vec    → looks for std/core/vec.tr
+    #   from std.core.map import Map    → looks for std/core/map.tr
+
+    print("=== done ===")

--- a/examples/15_concurrency.tr
+++ b/examples/15_concurrency.tr
@@ -1,0 +1,164 @@
+# 15 — Concurrency
+# Covers: async/await (synchronous today, forward-compatible),
+# spawn (OS threads), task_group: (structured concurrency, joins threads),
+# shared (atomic reference-counted ownership across threads).
+
+# ── 1. async / await ──────────────────────────────────────────────────────────
+# 'async def' marks a function as a coroutine.
+# Today: 'await f(x)' is a direct function call — no scheduler, no heap future.
+# When a real async runtime is added, all async/await code will still work.
+async def fetch(id: int) -> str:
+    return f"item-{id}"
+
+async def process(n: int) -> int:
+    mut data = await fetch(n)
+    return len(data)
+
+async def pipeline(ids: List[int]) -> int:
+    mut total = 0
+    for id in ids:
+        mut r = await process(id)
+        total += r
+    return total
+
+# ── 2. spawn — OS threads ─────────────────────────────────────────────────────
+# spawn f(arg) starts a real OS thread (pthread on Linux/macOS, Win32 thread).
+# A spawn outside task_group: is DETACHED — fire and forget.
+def worker(id: int) -> void:
+    print(f"  worker {id} running")
+    # ... do CPU-bound work ...
+    print(f"  worker {id} done")
+
+# ── 3. Multiple arguments — pack into a class ─────────────────────────────────
+# spawn takes a single argument (packed into void* via uintptr_t).
+# For multiple args, create a class to hold them.
+class WorkArgs:
+    pub task_id:  int
+    pub priority: int
+    pub label:    str
+
+extend WorkArgs:
+    pub def init(id: int, pri: int, label: str) -> WorkArgs:
+        mut w = WorkArgs()
+        w.task_id  = id
+        w.priority = pri
+        w.label    = label
+        return w
+
+def task_worker(args: WorkArgs) -> void:
+    print(f"  task[{args.task_id}] pri={args.priority} '{args.label}'")
+
+# ── 4. task_group: — structured concurrency ───────────────────────────────────
+# Spawns inside task_group: are JOINED — all must finish before continuing.
+def compute(n: int) -> void:
+    mut result = n * n
+    print(f"  compute({n}) = {result}")
+
+# ── 5. shared — reference-counted ownership ───────────────────────────────────
+# 'shared' wraps a value in an atomic refcount box so multiple threads can
+# access the same object. The refcount is thread-safe; the data is NOT.
+class SharedCounter:
+    pub value: int
+
+extend SharedCounter:
+    pub def init() -> SharedCounter:
+        mut c = SharedCounter()
+        c.value = 0
+        return c
+
+    pub def increment(self) -> void:
+        self.value += 1
+
+    pub def get(self) -> int:
+        return self.value
+
+def increment_shared(c: SharedCounter) -> void:
+    c.increment()
+    print(f"  incremented to {c.get()}")
+
+def heavy_compute(n: int) -> void:
+    mut result = 0
+    mut i = 0
+    while i < n:
+        result += i * i
+        i += 1
+    print(f"  sum of squares 0..{n} = {result}")
+
+async def main():
+
+    # ── async/await ───────────────────────────────────────────────────────────
+    print("=== async / await ===")
+    mut r1 = await process(1)
+    mut r2 = await process(42)
+    print(f"process(1)  = {r1}")    # 6  (len("item-1"))
+    print(f"process(42) = {r2}")   # 7  (len("item-42"))
+
+    mut ids = [1, 2, 3, 10]
+    mut total = await pipeline(ids)
+    print(f"pipeline total chars = {total}")
+
+    # ── spawn (detached — no join) ────────────────────────────────────────────
+    # WARNING: detached threads may outlive main() if main exits too quickly.
+    # Use task_group: when you need to wait for completion.
+    print("=== spawn (detached) ===")
+    spawn worker(1)
+    spawn worker(2)
+    spawn worker(3)
+    print("  main thread continues immediately (workers may still be running)")
+
+    # ── task_group: — wait for all spawned threads ────────────────────────────
+    print("=== task_group: ===")
+    task_group:
+        spawn compute(4)
+        spawn compute(7)
+        spawn compute(12)
+    # ALL THREE are guaranteed finished here — task_group: joins them
+    print("  all compute() workers finished")
+
+    # ── task_group: with class args ───────────────────────────────────────────
+    print("=== task_group + class args ===")
+    task_group:
+        spawn task_worker(WorkArgs.init(1, 9, "urgent"))
+        spawn task_worker(WorkArgs.init(2, 3, "background"))
+        spawn task_worker(WorkArgs.init(3, 6, "normal"))
+    print("  all task_worker() finished")
+
+    # ── Nested task_group: blocks ─────────────────────────────────────────────
+    print("=== Nested task_group: ===")
+    task_group:
+        spawn compute(2)
+        spawn compute(3)
+    print("  phase 1 done")
+
+    task_group:
+        spawn compute(5)
+        spawn compute(6)
+    print("  phase 2 done")
+
+    # ── shared — reference-counted across threads ─────────────────────────────
+    print("=== shared ===")
+    mut counter = SharedCounter.init()
+    shared s1 = counter     # ref count = 1
+    shared s2 = s1          # ref count = 2 — same underlying counter
+
+    task_group:
+        spawn increment_shared(s1)    # thread 1
+        spawn increment_shared(s2)    # thread 2 — same SharedCounter!
+
+    # Both threads finished — but increment() is NOT atomic on .value.
+    # For this toy example the final value is likely 2, but it's technically
+    # a data race. Use an atomic int (via extern C) for real thread safety.
+    print(f"  counter after 2 threads: {s1.get()}")
+
+    # s1 drops → ref count = 1
+    # s2 drops → ref count = 0 → SharedCounter freed automatically
+
+    # ── Using spawn for parallel CPU work ─────────────────────────────────────
+    print("=== Parallel computation ===")
+    task_group:
+        spawn heavy_compute(100)
+        spawn heavy_compute(200)
+        spawn heavy_compute(300)
+    print("  all heavy computations done")
+
+    print("=== done ===")

--- a/examples/16_extern_and_ffi.tr
+++ b/examples/16_extern_and_ffi.tr
@@ -1,0 +1,162 @@
+# 16 — Extern and C FFI (Foreign Function Interface)
+# Covers: extern "C" declarations, calling C library functions,
+# struct interop, function pointer callbacks.
+# Tauraro compiles to C, giving zero-cost access to the entire C ecosystem.
+
+# ── 1. Declare C library functions ────────────────────────────────────────────
+# extern "C" emits C 'extern' prototypes in the output header.
+# Type mapping: float->double, str->char*, usize->size_t, Pointer[void]->void*
+#
+# Only declare functions whose C types map cleanly. The runtime already
+# includes <stdio.h>, <stdlib.h>, <string.h>, <math.h> — so sqrt, strcmp etc.
+# are available without re-declaration.
+
+extern "C":
+    # Math (from <math.h>) — float maps to double, which matches exactly
+    def sqrt(x: float) -> float
+    def pow(base: float, exp: float) -> float
+    def floor(x: float) -> float
+    def ceil(x: float) -> float
+    def fabs(x: float) -> float
+    def sin(x: float) -> float
+    def cos(x: float) -> float
+    def log(x: float) -> float
+    def atan2(y: float, x: float) -> float
+
+# ── 2. Safe wrappers ──────────────────────────────────────────────────────────
+def c_sqrt(x: float) -> float:
+    if x < 0.0: raise(f"sqrt of negative: {x}")
+    return sqrt(x)
+
+def c_hypot(x: float, y: float) -> float:
+    return sqrt(x * x + y * y)
+
+# ── 3. Struct interop — Tauraro class matching a C struct layout ──────────────
+# When a C library uses structs, declare a matching Tauraro class.
+# Field types must match exactly.
+
+class Vec2:
+    pub x: float
+    pub y: float
+
+extend Vec2:
+    pub def init(x: float, y: float) -> Vec2:
+        mut v = Vec2()
+        v.x = x
+        v.y = y
+        return v
+
+    pub def length(self) -> float:
+        return sqrt(self.x * self.x + self.y * self.y)
+
+    pub def dot(self, other: Vec2) -> float:
+        return self.x * other.x + self.y * other.y
+
+    pub def angle(self) -> float:
+        return atan2(self.y, self.x)
+
+# ── 4. Callback pattern — sort with a comparator function ─────────────────────
+# In C, you pass a function pointer as a callback.
+# In Tauraro, a 'lambda' parameter holds a reference to any callable.
+# Non-capturing top-level functions generate plain C functions,
+# which means they can be passed to C APIs that accept function pointers.
+
+def sort_ints_asc(items: List[int]) -> void:
+    mut n = len(items)
+    mut i = 0
+    while i < n:
+        mut j = 0
+        while j < n - i - 1:
+            mut a = items[j + 0]
+            mut b = items[j + 1]
+            if a > b:
+                items[j + 0] = b
+                items[j + 1] = a
+            j += 1
+        i += 1
+
+def sort_ints_desc(items: List[int]) -> void:
+    mut n = len(items)
+    mut i = 0
+    while i < n:
+        mut j = 0
+        while j < n - i - 1:
+            mut a = items[j + 0]
+            mut b = items[j + 1]
+            if a < b:
+                items[j + 0] = b
+                items[j + 1] = a
+            j += 1
+        i += 1
+
+# ── 5. Raw pointer operations (unsafe) ────────────────────────────────────────
+# alloc[T](n) wraps malloc; dealloc wraps free. Use for C interop buffers.
+
+def main():
+
+    # ── C math functions ──────────────────────────────────────────────────────
+    print("=== C Math ===")
+    print(f"sqrt(16.0)     = {sqrt(16.0)}")
+    print(f"sqrt(2.0)      = {c_sqrt(2.0)}")
+    print(f"pow(2.0, 10.0) = {pow(2.0, 10.0)}")
+    print(f"floor(3.7)     = {floor(3.7)}")
+    print(f"ceil(3.2)      = {ceil(3.2)}")
+    print(f"fabs(-9.5)     = {fabs(-9.5)}")
+    print(f"sin(0.0)       = {sin(0.0)}")
+    print(f"cos(0.0)       = {cos(0.0)}")
+    print(f"hypot(3,4)     = {c_hypot(3.0, 4.0)}")
+
+    # ── Struct interop ────────────────────────────────────────────────────────
+    print("=== Struct interop ===")
+    mut v1 = Vec2.init(3.0, 4.0)
+    mut v2 = Vec2.init(1.0, 0.0)
+    print(f"v1.length() = {v1.length()}")       # 5.0
+    print(f"v1 dot v2   = {v1.dot(v2)}")        # 3.0
+
+    # ── Memory management via Tauraro alloc/dealloc ───────────────────────────
+    # alloc[T](n) allocates n*sizeof(T) bytes, returns Pointer[T].
+    # dealloc(p) frees the allocation.
+    print("=== alloc / dealloc ===")
+    unsafe:
+        mut buf: Pointer[u8] = alloc[u8](128)
+        # write some bytes
+        buf.write(72 as u8)          # 'H'
+        buf.offset(1).write(105 as u8)   # 'i'
+        buf.offset(2).write(0 as u8)     # null terminator
+        # read them back
+        mut b0 = buf.read() as int
+        mut b1 = buf.offset(1).read() as int
+        print(f"  buf[0]={b0} buf[1]={b1}")   # 72 105
+        dealloc(buf)
+    print("  allocated 128 bytes, read/wrote, freed")
+
+    # ── Sorting with comparator functions ─────────────────────────────────────
+    # Top-level functions compile to plain C functions,
+    # so they can be passed as function pointers to C sort APIs.
+    print("=== Sort with comparator ===")
+    mut nums: List[int] = [5, 2, 8, 1, 9, 3, 7, 4, 6]
+
+    sort_ints_asc(nums)
+    print("ascending:")
+    mut i = 0
+    while i < len(nums):
+        mut v = nums[i + 0]
+        print(f"  {v}")
+        i += 1
+
+    sort_ints_desc(nums)
+    print("descending:")
+    mut j = 0
+    while j < len(nums):
+        mut v = nums[j + 0]
+        print(f"  {v}")
+        j += 1
+
+    # ── FFI best practices ────────────────────────────────────────────────────
+    # 1. Use extern "C" only for functions whose types map cleanly.
+    # 2. Wrap C calls in Tauraro functions for error checking.
+    # 3. Use alloc[T]/dealloc instead of malloc/free where possible.
+    # 4. Use unsafe: for all raw pointer arithmetic.
+    # 5. Keep the extern "C" block close to the functions that use it.
+
+    print("=== done ===")

--- a/examples/17_advanced_patterns.tr
+++ b/examples/17_advanced_patterns.tr
@@ -1,0 +1,357 @@
+# 17 -- Advanced Patterns
+# Covers: operator overloading, builder pattern, strategy pattern,
+# state machine (enum + class), memoization (class-based),
+# early-return guards, bit flags, observer pattern, dependency injection.
+
+extern "C":
+    def sqrt(x: float) -> float
+
+# -- 1. Operator Overloading --------------------------------------------------
+# Classes can define __add__, __sub__, __mul__, __eq__ etc. as regular methods.
+# Call them explicitly as a.__add__(b); operator syntax dispatching not yet impl.
+class Vec2:
+    pub x: float
+    pub y: float
+
+extend Vec2:
+    pub def init(x: float, y: float) -> Vec2:
+        mut v = Vec2()
+        v.x = x
+        v.y = y
+        return v
+
+    pub def __add__(self, other: Vec2) -> Vec2:
+        return Vec2.init(self.x + other.x, self.y + other.y)
+
+    pub def __sub__(self, other: Vec2) -> Vec2:
+        return Vec2.init(self.x - other.x, self.y - other.y)
+
+    pub def __mul__(self, scalar: float) -> Vec2:
+        return Vec2.init(self.x * scalar, self.y * scalar)
+
+    pub def __eq__(self, other: Vec2) -> bool:
+        return self.x == other.x and self.y == other.y
+
+    pub def __str__(self) -> str:
+        return f"({self.x}, {self.y})"
+
+    pub def dot(self, other: Vec2) -> float:
+        return self.x * other.x + self.y * other.y
+
+    pub def length(self) -> float:
+        return sqrt(self.x * self.x + self.y * self.y)
+
+# -- 2. Builder Pattern -------------------------------------------------------
+# Construct complex objects step-by-step with method chaining.
+class HttpRequest:
+    pub url:     str
+    pub method:  str
+    pub body:    str
+    pub timeout: int
+
+extend HttpRequest:
+    pub def init() -> HttpRequest:
+        mut r = HttpRequest()
+        r.url     = ""
+        r.method  = "GET"
+        r.body    = ""
+        r.timeout = 30
+        return r
+
+    pub def with_url(self, url: str) -> HttpRequest:
+        self.url = url
+        return self
+
+    pub def with_method(self, method: str) -> HttpRequest:
+        self.method = method
+        return self
+
+    pub def with_body(self, body: str) -> HttpRequest:
+        self.body = body
+        return self
+
+    pub def with_timeout(self, seconds: int) -> HttpRequest:
+        self.timeout = seconds
+        return self
+
+    pub def describe(self) -> void:
+        print(f"  {self.method} {self.url} (timeout={self.timeout}s)")
+
+# -- 3. Strategy Pattern ------------------------------------------------------
+# Swap sort direction by picking a different comparator function.
+def cmp_asc(a: int, b: int) -> int:
+    if a < b: return -1
+    if a > b: return 1
+    return 0
+
+def cmp_desc(a: int, b: int) -> int:
+    if a > b: return -1
+    if a < b: return 1
+    return 0
+
+def insertion_sort_asc(data: List[int]) -> void:
+    mut i = 1
+    while i < len(data):
+        mut key = data[i + 0]
+        mut j = i - 1
+        while j >= 0 and cmp_asc(data[j + 0], key) > 0:
+            data[j + 1] = data[j + 0]
+            j -= 1
+        data[j + 1] = key
+        i += 1
+
+def insertion_sort_desc(data: List[int]) -> void:
+    mut i = 1
+    while i < len(data):
+        mut key = data[i + 0]
+        mut j = i - 1
+        while j >= 0 and cmp_desc(data[j + 0], key) > 0:
+            data[j + 1] = data[j + 0]
+            j -= 1
+        data[j + 1] = key
+        i += 1
+
+# -- 4. State Machine ---------------------------------------------------------
+# Encode states as an enum; transitions as methods on a class.
+enum ConnState:
+    Idle
+    Connecting
+    Connected
+    Disconnected(reason: str)
+
+class Connection:
+    pub state: ConnState
+    pub host:  str
+
+extend Connection:
+    pub def init(host: str) -> Connection:
+        mut c = Connection()
+        c.state = ConnState.Idle
+        c.host  = host
+        return c
+
+    pub def connect(self) -> void:
+        match self.state:
+            case ConnState.Idle:
+                self.state = ConnState.Connecting
+                print(f"  connecting to {self.host}...")
+                self.state = ConnState.Connected
+                print("  connected")
+            case ConnState.Connected:
+                print("  already connected")
+            case _:
+                print("  cannot connect in current state")
+
+    pub def disconnect(self, reason: str) -> void:
+        match self.state:
+            case ConnState.Connected:
+                self.state = ConnState.Disconnected(reason)
+                print(f"  disconnected: {reason}")
+            case _:
+                print("  not connected")
+
+    pub def status(self) -> str:
+        match self.state:
+            case ConnState.Idle:             return "idle"
+            case ConnState.Connecting:       return "connecting"
+            case ConnState.Connected:        return "connected"
+            case ConnState.Disconnected(r):  return f"disconnected: {r}"
+            case _:                          return "unknown"
+
+# -- 5. Memoization -----------------------------------------------------------
+# Pass memo state as a class so it's accessible from all helper functions.
+class FibMemo:
+    pub vals: List[int]
+    pub done: List[bool]
+
+extend FibMemo:
+    pub def init(n: int) -> FibMemo:
+        mut m = FibMemo()
+        m.vals = []
+        m.done = []
+        mut i = 0
+        while i <= n:
+            m.vals.append(-1)
+            m.done.append(false)
+            i += 1
+        return m
+
+def fib(n: int, memo: FibMemo) -> int:
+    if n <= 1: return n
+    mut dn = memo.done[n + 0]
+    if dn: return memo.vals[n + 0]
+    mut result = fib(n - 1, memo) + fib(n - 2, memo)
+    memo.vals[n + 0] = result
+    memo.done[n + 0] = true
+    return result
+
+# -- 6. Bit flags -------------------------------------------------------------
+def has_flag(perms: int, flag: int) -> bool:
+    return (perms & flag) != 0
+
+# Pass flag values as parameters so the function is self-contained.
+def flag_str(perms: int, fr: int, fw: int, fx: int, fh: int) -> str:
+    mut s = ""
+    if has_flag(perms, fr): s = s + "r"
+    if has_flag(perms, fw): s = s + "w"
+    if has_flag(perms, fx): s = s + "x"
+    if has_flag(perms, fh): s = s + "h"
+    return s
+
+# -- 7. Observer pattern (string-key dispatch) --------------------------------
+class EventBus:
+    pub subscribers: List[str]
+
+extend EventBus:
+    pub def init() -> EventBus:
+        mut b = EventBus()
+        b.subscribers = []
+        return b
+
+    pub def subscribe(self, key: str) -> void:
+        self.subscribers.append(key)
+
+    pub def emit(self, event: str) -> void:
+        mut i = 0
+        while i < len(self.subscribers):
+            mut key = self.subscribers[i + 0]
+            if key == "login":   print(f"  login: {event}")
+            elif key == "audit": print(f"  audit: {event}")
+            i += 1
+
+# -- 8. Early-return guard pattern --------------------------------------------
+def process(input: str) -> str:
+    if len(input) == 0: return ""
+    if input == "skip": return ""
+    return input.upper()
+
+# -- 9. Dependency injection via separate functions ---------------------------
+def verbose_transform(data: str) -> str:
+    print(f"  LOG: transforming: {data}")
+    return data.upper()
+
+def silent_transform(data: str) -> str:
+    return data.upper()
+
+def main():
+
+    # -- Operator overloading -------------------------------------------------
+    print("=== Operator Overloading ===")
+    mut a = Vec2.init(1.0, 2.0)
+    mut b = Vec2.init(3.0, 4.0)
+
+    mut c = a.__add__(b)
+    mut d = b.__sub__(a)
+    mut e = a.__mul__(3.0)
+
+    print(f"a = {a.__str__()}")
+    print(f"b = {b.__str__()}")
+    print(f"a + b = {c.__str__()}")
+    print(f"b - a = {d.__str__()}")
+    print(f"a * 3 = {e.__str__()}")
+    print(f"a.__eq__(a) = {a.__eq__(a)}")
+    print(f"a.__eq__(b) = {a.__eq__(b)}")
+    print(f"dot(a,b) = {a.dot(b)}")
+    print(f"|b| = {b.length()}")
+
+    # -- Builder pattern ------------------------------------------------------
+    print("=== Builder ===")
+    mut req = HttpRequest.init().with_url("https://api.example.com/data").with_method("POST").with_body("{}").with_timeout(60)
+    req.describe()
+    mut req2 = HttpRequest.init().with_url("https://example.com/health")
+    req2.describe()
+
+    # -- Strategy pattern -----------------------------------------------------
+    print("=== Strategy (sort) ===")
+    mut nums: List[int] = [5, 2, 8, 1, 9, 3]
+
+    insertion_sort_asc(nums)
+    print("ascending:")
+    mut si = 0
+    while si < len(nums):
+        mut sv = nums[si + 0]
+        print(f"  {sv}")
+        si += 1
+
+    insertion_sort_desc(nums)
+    print("descending:")
+    mut di = 0
+    while di < len(nums):
+        mut dv = nums[di + 0]
+        print(f"  {dv}")
+        di += 1
+
+    # -- State machine --------------------------------------------------------
+    print("=== State Machine ===")
+    mut conn = Connection.init("db.example.com")
+    print(f"  status: {conn.status()}")
+    conn.connect()
+    print(f"  status: {conn.status()}")
+    conn.connect()
+    conn.disconnect("timeout")
+    print(f"  status: {conn.status()}")
+    conn.disconnect("again")
+
+    # -- Memoization ----------------------------------------------------------
+    print("=== Memoization ===")
+    mut memo = FibMemo.init(40)
+    mut fi = 0
+    while fi <= 10:
+        mut fv = fib(fi, memo)
+        print(f"  fib({fi}) = {fv}")
+        fi += 1
+    mut fib30 = fib(30, memo)
+    print(f"  fib(30) = {fib30}")
+
+    # -- Swap with temp variable (no tuple swap syntax needed) ----------------
+    print("=== Swap ===")
+    mut x = 10
+    mut y = 20
+    print(f"  before: x={x} y={y}")
+    mut tmp = x
+    x = y
+    y = tmp
+    print(f"  after:  x={x} y={y}")
+
+    # -- Observer pattern -----------------------------------------------------
+    print("=== Observer ===")
+    mut bus = EventBus.init()
+    bus.subscribe("login")
+    bus.subscribe("audit")
+    bus.emit("user:logged_in")
+    bus.emit("user:logged_out")
+
+    # -- Bit flags ------------------------------------------------------------
+    print("=== Bit Flags ===")
+    mut flag_r = 1
+    mut flag_w = 2
+    mut flag_x = 4
+    mut flag_h = 8
+    mut perms = flag_r | flag_w
+    print(f"  perms: {flag_str(perms, flag_r, flag_w, flag_x, flag_h)}")
+
+    perms = perms | flag_x
+    print(f"  after +exec: {flag_str(perms, flag_r, flag_w, flag_x, flag_h)}")
+
+    perms = perms & ~flag_w
+    print(f"  after -write: {flag_str(perms, flag_r, flag_w, flag_x, flag_h)}")
+
+    perms = perms ^ flag_h
+    print(f"  after ^hidden: {flag_str(perms, flag_r, flag_w, flag_x, flag_h)}")
+
+    # -- Early return guards --------------------------------------------------
+    print("=== Early Return Guards ===")
+    mut hello_in = "hello"
+    mut empty_in = ""
+    mut skip_in  = "skip"
+    print(f"  process(hello) = {process(hello_in)}")
+    print(f"  process(empty) = {process(empty_in)}")
+    print(f"  process(skip)  = {process(skip_in)}")
+
+    # -- Dependency injection -------------------------------------------------
+    print("=== Dependency Injection ===")
+    mut r1 = verbose_transform("hello")
+    mut r2 = silent_transform("world")
+    print(f"  r1={r1}  r2={r2}")
+
+    print("=== done ===")

--- a/examples/vec_example.tr
+++ b/examples/vec_example.tr
@@ -1,0 +1,113 @@
+# examples/vec_example.tr
+# Demonstrates Vec[T] operations and documents the is_empty() type-inference
+# workaround: use  v.len == 0  directly instead of  v.is_empty().
+
+from std.core.vec import Vec
+
+extern "C":
+    def _tr_float_to_str(n: float) -> str
+
+# ── helper: print bool safely ────────────────────────────────────────────────
+# print(v.is_empty()) triggers a type-inference bug on bool results from
+# generic-class methods — the codegen loses the bool type and emits a bad cast.
+# Use v.len == 0 for the condition and this helper for display.
+def bool_str(b: bool) -> str:
+    if b: return "true"
+    return "false"
+
+def main():
+
+    # ── 1. init & push ───────────────────────────────────────────────────────
+    mut v = Vec[int].init(4)
+    print("=== push 1..5 ===")
+    mut i = 1
+    while i <= 5:
+        v.push(i)
+        i = i + 1
+    print("len: " + str(v.len))               # 5
+
+    # ── 2. is_empty workaround ───────────────────────────────────────────────
+    # BUG: print(v.is_empty())  — type-inference fails for bool on generic method
+    # FIX: compare v.len directly
+    print("is_empty (len==0): " + bool_str(v.len == 0))   # false
+    print("is_empty (len==0): " + bool_str(v.len == 0))   # false (repeat for clarity)
+
+    # ── 3. get ───────────────────────────────────────────────────────────────
+    print("=== get ===")
+    print("v[0]: " + str(v.get(0)))            # 1
+    print("v[4]: " + str(v.get(4)))            # 5
+
+    # ── 4. set ───────────────────────────────────────────────────────────────
+    print("=== set ===")
+    v.set(2, 99)
+    print("v[2] after set(2,99): " + str(v.get(2)))   # 99
+
+    # ── 5. contains ──────────────────────────────────────────────────────────
+    print("=== contains ===")
+    print("contains 99: " + bool_str(v.contains(99)))   # true
+    print("contains  3: " + bool_str(v.contains(3)))    # false (was overwritten)
+    print("contains  1: " + bool_str(v.contains(1)))    # true
+
+    # ── 6. pop ───────────────────────────────────────────────────────────────
+    print("=== pop ===")
+    mut popped = v.pop()
+    print("popped: " + str(popped))            # 5
+    print("len after pop: " + str(v.len))      # 4
+
+    # ── 7. remove ────────────────────────────────────────────────────────────
+    print("=== remove index 0 ===")
+    v.remove(0)
+    print("v[0] after remove(0): " + str(v.get(0)))   # 2
+    print("len after remove: " + str(v.len))           # 3
+
+    # ── 8. swap ──────────────────────────────────────────────────────────────
+    print("=== swap 0,1 ===")
+    v.swap(0, 1)
+    print("v[0]: " + str(v.get(0)))   # 99
+    print("v[1]: " + str(v.get(1)))   # 2
+
+    # ── 9. extend ────────────────────────────────────────────────────────────
+    print("=== extend ===")
+    mut extra = Vec[int].init(2)
+    extra.push(10)
+    extra.push(20)
+    v.extend(extra)
+    print("len after extend: " + str(v.len))   # 5
+    print("v[3]: " + str(v.get(3)))            # 10
+    print("v[4]: " + str(v.get(4)))            # 20
+
+    # ── 10. clear ────────────────────────────────────────────────────────────
+    print("=== clear ===")
+    v.clear()
+    print("len after clear: " + str(v.len))                   # 0
+    print("is_empty (len==0): " + bool_str(v.len == 0))       # true
+
+    # ── 11. Vec[str] ─────────────────────────────────────────────────────────
+    print("=== Vec[str] ===")
+    mut words = Vec[str].init(4)
+    words.push("hello")
+    words.push("tauraro")
+    words.push("world")
+    print("len: " + str(words.len))                          # 3
+    print("words[1]: " + words.get(1))                       # tauraro
+    print("contains 'world': " + bool_str(words.contains("world")))   # true
+    print("contains 'rust':  " + bool_str(words.contains("rust")))    # false
+
+    # ── 12. Vec[f64] ─────────────────────────────────────────────────────────
+    print("=== Vec[f64] ===")
+    mut floats = Vec[f64].init(4)
+    floats.push(1.5)
+    floats.push(2.5)
+    floats.push(3.5)
+    mut sum: f64 = 0.0
+    mut fi = 0
+    while fi < floats.len:
+        sum = sum + floats.get(fi)
+        fi = fi + 1
+    print("sum: " + _tr_float_to_str(sum))   # 7.500000
+
+    v.free()
+    extra.free()
+    words.free()
+    floats.free()
+    print("=== done ===")

--- a/src/codegen/c.tr
+++ b/src/codegen/c.tr
@@ -264,6 +264,38 @@ pub class CGenerator:
         if n == "char": return "char"
         if _is_str_type(n): return "char*"
 
+        # FFI / C interop types
+        if n == "c_int": return "int"
+        if n == "c_long": return "long"
+        if n == "c_longlong": return "long long"
+        if n == "c_uint": return "unsigned int"
+        if n == "c_ulong": return "unsigned long"
+        if n == "c_ulonglong": return "unsigned long long"
+        if n == "c_short": return "short"
+        if n == "c_ushort": return "unsigned short"
+        if n == "c_char": return "char"
+        if n == "c_uchar": return "unsigned char"
+        if n == "c_schar": return "signed char"
+        if n == "c_float": return "float"
+        if n == "c_double": return "double"
+        if n == "c_ldouble": return "long double"
+        if n == "c_void_ptr" or n == "RawPtr": return "void*"
+        if n == "c_size_t": return "size_t"
+        if n == "c_ssize_t": return "ssize_t"
+        if n == "c_ptrdiff_t": return "ptrdiff_t"
+        if n == "c_intptr_t": return "intptr_t"
+        if n == "c_uintptr_t": return "uintptr_t"
+        if n == "c_int8_t": return "int8_t"
+        if n == "c_int16_t": return "int16_t"
+        if n == "c_int32_t": return "int32_t"
+        if n == "c_int64_t": return "int64_t"
+        if n == "c_uint8_t": return "uint8_t"
+        if n == "c_uint16_t": return "uint16_t"
+        if n == "c_uint32_t": return "uint32_t"
+        if n == "c_uint64_t": return "uint64_t"
+        if n == "CFile" or n == "c_FILE": return "FILE*"
+        if n == "CString": return "char*"
+
         # Check if it's a generic type parameter in current function
         if self.cur_func != "":
             if self.functions.contains(self.cur_func):
@@ -337,6 +369,7 @@ pub class CGenerator:
 
         if n == "Result": return "Result"
         if n == "Option": return "Option"
+        if n == "lambda": return "void*"
         if self.enums.contains(n): return n
         if self.interfaces.contains(n): return n + "_obj"
         return n + "*"
@@ -582,14 +615,29 @@ pub class CGenerator:
 
     # ── Struct generation ─────────────────────────────────────────────────────
 
+    pub def emit_base_fields(self, base_name: str):
+        if self.classes.contains(base_name):
+            mut base_cls: HirClass = self.classes.get(base_name)
+            mut bfi: int = 0
+            while bfi < base_cls.fields.len:
+                mut bf: HirField = base_cls.fields.get(bfi)
+                self.ws("    " + self.type_to_c(bf.ty) + " " + bf.name + ";\n")
+                bfi = bfi + 1
+
     pub def gen_class_struct(self, c: HirClass):
         self.ws("typedef struct " + c.name + " {\n")
-        mut i = 0
+        # Emit inherited fields first (single-level inheritance via field copying)
+        mut bi: int = 0
+        while bi < c.base_classes.len:
+            mut base_name: str = c.base_classes.get(bi)
+            self.emit_base_fields(base_name)
+            bi = bi + 1
+        mut i: int = 0
         while i < c.fields.len:
-            mut f = c.fields.get(i)
+            mut f: HirField = c.fields.get(i)
             self.ws("    " + self.type_to_c(f.ty) + " " + f.name + ";\n")
             i = i + 1
-        if c.fields.len == 0:
+        if c.fields.len == 0 and c.base_classes.len == 0:
             self.ws("    char _pad;\n")
         self.ws("} " + c.name + ";\n\n")
 
@@ -671,7 +719,9 @@ pub class CGenerator:
             self.ws(");\n")
             i = i + 1
         self.ws("} " + iface.name + "_vtable;\n\n")
-        self.ws("typedef struct { " + iface.name + "_vtable* vtable; void* data; } " + iface.name + "_obj;\n\n")
+        if not self.emitted_fns.contains("iface_obj_" + iface.name):
+            self.emitted_fns.insert("iface_obj_" + iface.name, true)
+            self.ws("typedef struct { " + iface.name + "_vtable* vtable; void* data; } " + iface.name + "_obj;\n\n")
 
     # Build the static-inline _as_ wrap function string for one class+interface pair.
     # Called from generate_types_header (appended after all prototypes).
@@ -753,7 +803,10 @@ pub class CGenerator:
             case HirExpr.ERange(start, end, inclusive, _):
                 return self.gen_expr(start)
             case HirExpr.ESuperMethodCall(base, method, args, _):
-                mut sig = base + "_" + method + "((void*)self"
+                mut super_mc: str = method
+                if _is_c_keyword(super_mc):
+                    super_mc = "_tr_fn_" + super_mc
+                mut sig = base + "_" + super_mc + "((" + base + "*)self"
                 mut i = 0
                 while i < args.len:
                     sig = sig + ", " + self.gen_expr(args.get(i))
@@ -797,7 +850,13 @@ pub class CGenerator:
         if op == "and": return "(" + ls + " && " + rs + ")"
         if op == "or": return "(" + ls + " || " + rs + ")"
         if op == "is": return "(" + ls + " == " + rs + ")"
-        if op == "in": return "_tr_contains(" + ls + ", " + rs + ")"
+        if op == "in":
+            if rt_n == "List" or rt_n == "Vec":
+                mut in_sfx: str = self.list_elem_suffix(lt_n)
+                return "List_" + in_sfx + "_contains(" + rs + ", " + ls + ")"
+            if rt_n == "Map" or rt_n == "Dict":
+                return "_tr_dict_contains(" + rs + ", " + ls + ")"
+            return "_tr_contains(" + rs + ", " + ls + ")"
         if op == "**": return "((long long)pow((double)(" + ls + "), (double)(" + rs + ")))"
         if op == "//": return "((long long)(" + ls + ") / (long long)(" + rs + "))"
         if (_is_str_type(lt_n) or _is_str_type(rt_n)) and (op == "==" or op == "!="):
@@ -852,6 +911,9 @@ pub class CGenerator:
                     mut opt_ct = self.type_to_c(full_opt_ty.args.get(0).read())
                     return "((" + opt_ct + ")(" + obj_s + ".data.Some.val))"
                 return obj_s + ".data.Some.val"
+            # Handle Option.None / Option.Some as static constructors (p may be empty if None is a keyword)
+            if p == "" or p == "None" or p == "none": return "((Option){.tag=Option_None})"
+            if p == "Some" or p == "some": return "((Option){.tag=Option_None})"
             return obj_s + "." + p
         if self.interfaces.contains(t_n) and self.interfaces as usize != 0 as usize:
             return obj_s + "." + p
@@ -920,7 +982,10 @@ pub class CGenerator:
 
         # ord / chr — character conversions
         if base_callee == "ord":
-            if args.len > 0: return "((long long)(unsigned char)(" + self.gen_expr(args.get(0)) + ")[0])"
+            if args.len > 0:
+                mut ord_t_n: str = hir_expr_type(args.get(0)).name
+                if ord_t_n == "char": return "((long long)(unsigned char)(" + self.gen_expr(args.get(0)) + "))"
+                return "((long long)(unsigned char)(" + self.gen_expr(args.get(0)) + ")[0])"
             return "0LL"
         if base_callee == "chr":
             if args.len > 0: return "((char)(" + self.gen_expr(args.get(0)) + "))"
@@ -965,12 +1030,16 @@ pub class CGenerator:
                 return "(char*)(" + self.gen_expr(str_arg) + ")"
             return "\"\""
 
-        # int() / float() / bool() — type coercions
-        if base_callee == "int":
-            if args.len > 0: return "(long long)(" + self.gen_expr(args.get(0)) + ")"
+        # int() / float() / bool() — type coercions; int/float from str → parse
+        if base_callee == "int" or base_callee == "_tr_fn_int":
+            if args.len > 0:
+                if _is_str_type(hir_expr_type(args.get(0)).name): return "_tr_str_to_int(" + self.gen_expr(args.get(0)) + ")"
+                return "(long long)(" + self.gen_expr(args.get(0)) + ")"
             return "0LL"
         if base_callee == "float" or base_callee == "_tr_fn_float":
-            if args.len > 0: return "(double)(" + self.gen_expr(args.get(0)) + ")"
+            if args.len > 0:
+                if _is_str_type(hir_expr_type(args.get(0)).name): return "_tr_str_to_float(" + self.gen_expr(args.get(0)) + ")"
+                return "(double)(" + self.gen_expr(args.get(0)) + ")"
             return "0.0"
         if base_callee == "bool":
             if args.len > 0: return "(_Bool)(" + self.gen_expr(args.get(0)) + ")"
@@ -1170,6 +1239,20 @@ pub class CGenerator:
                     ai = ai + 1
                 return callee_s + "(" + wrapped_args + ")"
 
+        # Lambda / void* function pointer: cast to typed function pointer before calling
+        mut callee_ty_n: str = hir_expr_type(callee).name
+        if callee_ty_n == "lambda" or callee_ty_n == "void*":
+            mut ret_cty = self.type_to_c(call_ty)
+            if ret_cty == "void": ret_cty = "long long"
+            mut arg_types = ""
+            mut ai2 = 0
+            while ai2 < args.len:
+                if ai2 > 0: arg_types = arg_types + ", "
+                arg_types = arg_types + self.type_to_c(hir_expr_type(args.get(ai2)))
+                ai2 = ai2 + 1
+            if arg_types == "": arg_types = "void"
+            return "((" + ret_cty + "(*)(" + arg_types + "))(" + callee_s + "))(" + self.gen_args(args) + ")"
+
         return callee_s + "(" + self.gen_args(args) + ")"
 
     pub def gen_print_call(self, args: Vec[Pointer[HirExpr]]) -> str:
@@ -1310,6 +1393,19 @@ pub class CGenerator:
         if method == "contains" and args.len > 0 and _is_str_type(t_n):
             return "_tr_str_contains(" + obj_s + ", " + self.gen_expr(args.get(0)) + ")"
 
+        # String method dispatch — must be before the generic TrStr_ fallback
+        if _is_str_type(t_n):
+            if method == "upper": return "_tr_str_upper(" + obj_s + ")"
+            if method == "lower": return "_tr_str_lower(" + obj_s + ")"
+            if method == "strip": return "_tr_str_strip(" + obj_s + ")"
+            if method == "replace" and args.len == 2:
+                return "_tr_str_replace(" + obj_s + ", " + self.gen_expr(args.get(0)) + ", " + self.gen_expr(args.get(1)) + ")"
+            if method == "split" and args.len > 0:
+                return "_tr_str_split(" + obj_s + ", " + self.gen_expr(args.get(0)) + ")"
+            if method == "find" and args.len > 0:
+                mut tmp_find: str = self.next_temp()
+                return "({ char* " + tmp_find + " = strstr(" + obj_s + ", " + self.gen_expr(args.get(0)) + "); " + tmp_find + " ? (long long)(" + tmp_find + " - (" + obj_s + ")) : -1LL; })"
+
         mut class_name: str = t_n
         if _is_str_type(class_name): class_name = "TrStr"
 
@@ -1397,6 +1493,22 @@ pub class CGenerator:
                 return class_name + "_" + method_c + "(" + self.gen_args(args) + ")"
             if obj_s == class_name:
                 return class_name + "_" + method_c + "(" + self.gen_args(args) + ")"
+            # Check if method exists in own class; if not, fall back to base class dispatch
+            mut ucls_inh: HirClass = self.classes.get(class_name)
+            mut has_own_method: bool = false
+            mut mci: int = 0
+            while mci < ucls_inh.methods.len:
+                mut mdef: HirFunction = ucls_inh.methods.get(mci)
+                if mdef.name == method:
+                    has_own_method = true
+                mci = mci + 1
+            if not has_own_method and ucls_inh.base_classes.len > 0:
+                mut base_cls_n: str = ucls_inh.base_classes.get(0)
+                if self.classes.contains(base_cls_n):
+                    mut s_base: str = base_cls_n + "_" + method_c + "((" + base_cls_n + "*)" + obj_s
+                    if args.len > 0:
+                        s_base = s_base + ", " + self.gen_args(args)
+                    return s_base + ")"
             mut s = class_name + "_" + method_c + "(" + obj_s
             if args.len > 0: s = s + ", " + self.gen_args(args)
             return s + ")"
@@ -1563,7 +1675,15 @@ pub class CGenerator:
         return s + l + "; })"
 
     pub def gen_dict_literal(self, keys: Vec[Pointer[HirExpr]], vals: Vec[Pointer[HirExpr]]) -> str:
-        mut s = "_tr_dict_new(" + str(keys.len) + "LL)"
+        if keys.len == 0:
+            return "_tr_dict_new(0LL)"
+        mut tmp = self.next_temp()
+        mut s = "({ TrMap* " + tmp + " = _tr_dict_new(" + str(keys.len) + "LL); "
+        mut i = 0
+        while i < keys.len:
+            s = s + "_tr_dict_set(" + tmp + ", " + self.gen_expr(keys.get(i)) + ", " + self.gen_expr(vals.get(i)) + "); "
+            i = i + 1
+        s = s + tmp + "; })"
         return s
 
     pub def gen_list_comp(self, element: Pointer[HirExpr], generators: Vec[Pointer[HirComprehension]]) -> str:
@@ -1598,23 +1718,21 @@ pub class CGenerator:
     pub def gen_closure(self, params: Vec[HirParam], ret_ty: AstType, body: HirBlock) -> str:
         self.closure_count = self.closure_count + 1
         mut cname = "_closure_" + self.closure_count.to_str()
-        self.wp("static __attribute__((hot)) ")
-        self.wp(self.type_to_c(ret_ty) + " " + cname + "(")
-        mut first = true
-        mut i = 0
+        mut ret_c = self.type_to_c(ret_ty)
+        if ret_c == "void": ret_c = "long long"
+        self.w("    " + ret_c + " " + cname + "(")
+        mut first: bool = true
+        mut i: int = 0
         while i < params.len:
-            mut p = params.get(i)
-            if not first: self.wp(", ")
-            self.wp(self.type_to_c(p.ty) + " " + p.name)
+            mut p: HirParam = params.get(i)
+            if not first: self.w(", ")
+            self.w(self.type_to_c(p.ty) + " " + p.name)
             first = false
             i = i + 1
-        self.wp(") {\n")
-        mut old_buf = self.buf
-        self.buf = self.proto_buf
-        self.gen_block(body, 1)
-        self.buf = old_buf
-        self.wp("}\n\n")
-        return cname
+        self.w(") {\n")
+        self.gen_block(body, 2)
+        self.w("    }\n")
+        return "(void*)(&" + cname + ")"
 
     # ── Spawn wrapper pre-scan ────────────────────────────────────────────────
 
@@ -1636,7 +1754,7 @@ pub class CGenerator:
                     mut cast_back = "(long long)(uintptr_t)_vp"
                     if not _is_int_type(arg_ty_n) and arg_ty_n != "bool" and arg_ty_n != "char":
                         mut c_arg_ty = self.type_to_c(hir_expr_type(args.get(0)))
-                        cast_back = "(" + c_arg_ty + "*)_vp"
+                        cast_back = "(" + c_arg_ty + ")_vp"
                     self.w("static void* _tr_spawn_wrap_" + fn_name + "(void* _vp) { " + fn_name + "(" + cast_back + "); return NULL; }\n")
                 else:
                     self.w("static void* _tr_spawn_wrap_" + fn_name + "(void* _vp) { (void)_vp; /* multi-arg spawn not supported */ return NULL; }\n")
@@ -2012,7 +2130,10 @@ pub class CGenerator:
                                 start_s = self.gen_expr(args.get(0))
                                 end_s = self.gen_expr(args.get(1))
                                 step_s = self.gen_expr(args.get(2))
-                            self.w(pad + "for (long long " + var + " = " + start_s + "; " + var + " < " + end_s + "; " + var + " += " + step_s + ") {\n")
+                            mut cmp = "<"
+                            mut step_p = step_s as Pointer[char]
+                            if step_p.offset(0).read() as int == 45: cmp = ">"
+                            self.w(pad + "for (long long " + var + " = " + start_s + "; " + var + " " + cmp + " " + end_s + "; " + var + " += " + step_s + ") {\n")
                             self.gen_block(body, indent + 1)
                             self.w(pad + "}\n")
                             return
@@ -2021,10 +2142,18 @@ pub class CGenerator:
 
         # Generic iteration over a collection
         mut tmp = self.next_temp()
+        mut iter_ty = hir_expr_type(iter)
+        mut elem_c = "__auto_type"
+        if iter_ty.name == "List" or iter_ty.name == "Vec":
+            if iter_ty.args.len > 0:
+                elem_c = self.type_to_c(iter_ty.args.get(0).read())
         self.w(pad + "{ long long " + tmp + "_i = 0;\n")
         self.w(pad + "  __auto_type " + tmp + "_col = " + iter_s + ";\n")
         self.w(pad + "  while (" + tmp + "_i < " + tmp + "_col->len) {\n")
-        self.w(pad + "    __auto_type " + var + " = " + tmp + "_col->data[" + tmp + "_i];\n")
+        if elem_c == "__auto_type":
+            self.w(pad + "    __auto_type " + var + " = " + tmp + "_col->data[" + tmp + "_i];\n")
+        else:
+            self.w(pad + "    " + elem_c + " " + var + " = (" + elem_c + ")" + tmp + "_col->data[" + tmp + "_i];\n")
         self.gen_block(body, indent + 2)
         self.w(pad + "    " + tmp + "_i++;\n")
         self.w(pad + "  }\n")
@@ -2086,10 +2215,17 @@ pub class CGenerator:
                     if v: cond = subj
                     else: cond = "!" + subj
                 case Pattern.PLitStr(v): cond = "_tr_str_eq(" + subj + ", \"" + _escape_str_for_c(v) + "\")"
-                case Pattern.PVariant(tn, vn): cond = subj + ".tag == " + tn + "_" + vn
+                case Pattern.PVariant(tn, vn):
+                    mut pv_vn = vn
+                    if tn == "Option" and (vn == "" or vn == "none"): pv_vn = "None"
+                    cond = subj + ".tag == " + tn + "_" + pv_vn
                 case Pattern.PVariantBind(tn, vn, field):
                     cond = subj + ".tag == " + tn + "_" + vn
                     mut actual_fld = field
+                    # Built-in Option/Result: use known field names
+                    if tn == "Option" and vn == "Some": actual_fld = "val"
+                    if tn == "Result" and vn == "Ok": actual_fld = "val"
+                    if tn == "Result" and vn == "Err": actual_fld = "err"
                     if self.enums.contains(tn):
                         mut _ev_def = self.enums.get(tn)
                         mut _vi = 0
@@ -2127,7 +2263,10 @@ pub class CGenerator:
                         mut pp = pats.get(oi)
                         mut pc = "1"
                         match pp:
-                            case Pattern.PVariant(tn, vn): pc = subj + ".tag == " + tn + "_" + vn
+                            case Pattern.PVariant(tn, vn):
+                                mut or_vn = vn
+                                if tn == "Option" and (vn == "" or vn == "none"): or_vn = "None"
+                                pc = subj + ".tag == " + tn + "_" + or_vn
                             case Pattern.PLitInt(vi): pc = subj + " == " + vi.to_str() + "LL"
                             case Pattern.PLitStr(vs): pc = "_tr_str_eq(" + subj + ", \"" + _escape_str_for_c(vs) + "\")"
                             case Pattern.PLitBool(bv):
@@ -2577,6 +2716,10 @@ pub class CGenerator:
             mut iface2 = prog.interfaces.get(i)
             if not _is_invalid_ptr(iface2 as usize):
                 out.append("typedef struct _" + iface2.name + "_vtable " + iface2.name + "_vtable;\n")
+                # _obj typedef only needs a pointer to vtable (already fwd-declared above),
+                # so emit it here before any function prototypes reference it.
+                out.append("typedef struct { " + iface2.name + "_vtable* vtable; void* data; } " + iface2.name + "_obj;\n")
+                self.emitted_fns.insert("iface_obj_" + iface2.name, true)
             i = i + 1
         self.emit_list_fwd_decls(prog)          # writes to self.buf
         out.append(self.buf.to_string().as_str())

--- a/src/parser.tr
+++ b/src/parser.tr
@@ -119,6 +119,14 @@ extend Parser:
             case Token.KwExtend:
                 self.pos = self.pos + 1
                 return "extend"
+            # 'None' is KwNone but also a valid variant name in patterns like Option.None
+            case Token.KwNone:
+                self.pos = self.pos + 1
+                return "None"
+            # 'lambda' is KwLambda but used as a type name for function pointer params
+            case Token.KwLambda:
+                self.pos = self.pos + 1
+                return "lambda"
             case _:
                 pass
         return ""
@@ -772,6 +780,14 @@ extend Parser:
 
     pub def parse_comparison(self) -> Pointer[Expr]:
         mut left = self.parse_bitor_expr()
+        # Handle 'not in' compound operator before the standard match
+        if self.peek() == Token.KwNot:
+            mut saved_pos = self.pos
+            self.pos = self.pos + 1
+            if self.peek() == Token.KwIn:
+                self.pos = self.pos + 1
+                return box_expr(Expr.EUnaryOp("not", box_expr(Expr.EBinOp("in", left, self.parse_bitor_expr()))))
+            self.pos = saved_pos
         match self.peek():
             case Token.EqEq:
                 self.pos = self.pos + 1
@@ -1003,31 +1019,46 @@ extend Parser:
             case Token.KwVoid:
                 self.pos = self.pos + 1
                 return box_expr(Expr.EIdent("void"))
-            case Token.Ident(name):
+            case Token.KwSuper:
                 self.pos = self.pos + 1
-                if name == "super":
-                    mut base_class = ""
+                mut super_base: str = ""
+                if self.peek() == Token.LParen:
+                    self.pos = self.pos + 1
+                    super_base = self.consume_ident()
+                    if self.peek() == Token.RParen:
+                        self.pos = self.pos + 1
                     if self.peek() == Token.Dot:
                         self.pos = self.pos + 1
-                        mut next_id = self.consume_ident()
-                        if self.peek() == Token.Dot:
+                        mut super_method: str = self.consume_ident()
+                        if self.peek() == Token.LParen:
                             self.pos = self.pos + 1
-                            base_class = next_id
-                            mut method = self.consume_ident()
-                            if self.peek() == Token.LParen:
-                                self.pos = self.pos + 1
-                                mut args = self.parse_arg_list()
-                                return box_expr(Expr.ESuperMethodCall(base_class, method, args))
-                            else:
-                                return box_expr(Expr.ESuperPropAccess(base_class, method))
+                            mut super_args = self.parse_arg_list()
+                            return box_expr(Expr.ESuperMethodCall(super_base, super_method, super_args))
                         else:
-                            mut method = next_id
-                            if self.peek() == Token.LParen:
-                                self.pos = self.pos + 1
-                                mut args = self.parse_arg_list()
-                                return box_expr(Expr.ESuperMethodCall("", method, args))
-                            else:
-                                return box_expr(Expr.ESuperPropAccess("", method))
+                            return box_expr(Expr.ESuperPropAccess(super_base, super_method))
+                if self.peek() == Token.Dot:
+                    self.pos = self.pos + 1
+                    mut super_next: str = self.consume_ident()
+                    if self.peek() == Token.Dot:
+                        self.pos = self.pos + 1
+                        super_base = super_next
+                        mut super_method2: str = self.consume_ident()
+                        if self.peek() == Token.LParen:
+                            self.pos = self.pos + 1
+                            mut super_args2 = self.parse_arg_list()
+                            return box_expr(Expr.ESuperMethodCall(super_base, super_method2, super_args2))
+                        else:
+                            return box_expr(Expr.ESuperPropAccess(super_base, super_method2))
+                    else:
+                        if self.peek() == Token.LParen:
+                            self.pos = self.pos + 1
+                            mut super_args3 = self.parse_arg_list()
+                            return box_expr(Expr.ESuperMethodCall("", super_next, super_args3))
+                        else:
+                            return box_expr(Expr.ESuperPropAccess("", super_next))
+                return box_expr(Expr.EIdent("super"))
+            case Token.Ident(name):
+                self.pos = self.pos + 1
                 return box_expr(Expr.EIdent(name))
             case Token.KwSizeOf:
                 self.pos = self.pos + 1
@@ -1479,6 +1510,12 @@ extend Parser:
                     self.pos = self.pos + 1
             if self.peek() == Token.RBracket:
                 self.pos = self.pos + 1
+        if self.peek() == Token.KwExtends:
+            self.pos = self.pos + 1
+            c.base_classes.push(self.consume_ident())
+            while self.peek() == Token.Comma:
+                self.pos = self.pos + 1
+                c.base_classes.push(self.consume_ident())
         if self.peek() == Token.KwImplements:
             self.pos = self.pos + 1
             while True:

--- a/src/sema.tr
+++ b/src/sema.tr
@@ -401,7 +401,7 @@ extend Sema:
         hc.generics = c.generics
         hc.fields = hfields
         hc.methods = hmethods
-        hc.base_classes = c.iface_names
+        hc.base_classes = c.base_classes
         hc.iface_names = c.iface_names
         hc.decorators = c.decorators
         hc.is_public = c.is_public
@@ -550,8 +550,16 @@ extend Sema:
                 return box_hirstmt(HirStmt.SWhile(self.lower_expr(cond), self.lower_block(body)))
             case Stmt.SFor(var, iter, body, decorators):
                 self.enter_scope()
-                self.declare(var, SymbolKind.SVariable, box_asttype(AstType.init("int")), false)
-                mut hstmt = box_hirstmt(HirStmt.SFor(var, self.lower_expr(iter), self.lower_block(body)))
+                mut h_iter_for = self.lower_expr(iter)
+                mut var_ty_for = AstType.init("int")
+                mut iter_hn = hir_expr_type(h_iter_for).name
+                mut iter_hal = hir_expr_type(h_iter_for).args.len
+                if (iter_hn == "List" or iter_hn == "Vec") and iter_hal > 0:
+                    var_ty_for = hir_expr_type(h_iter_for).args.get(0).read()
+                elif iter_hn == "str":
+                    var_ty_for = AstType.init("char")
+                self.declare(var, SymbolKind.SVariable, box_asttype(var_ty_for), false)
+                mut hstmt = box_hirstmt(HirStmt.SFor(var, h_iter_for, self.lower_block(body)))
                 self.exit_scope()
                 return hstmt
             case Stmt.SMatch(subj, arms):
@@ -978,6 +986,127 @@ extend Sema:
                 mut hinner_await = self.lower_expr(inner_await)
                 mut await_ty = hir_expr_type(hinner_await)
                 return box_hirexpr(HirExpr.EAwait(hinner_await, await_ty))
+            case Expr.EDict(keys, vals):
+                mut h_keys = Vec[Pointer[HirExpr]].init(keys.len)
+                mut h_vals = Vec[Pointer[HirExpr]].init(vals.len)
+                mut di = 0
+                while di < keys.len:
+                    h_keys.push(self.lower_expr(keys.get(di)))
+                    h_vals.push(self.lower_expr(vals.get(di)))
+                    di = di + 1
+                return box_hirexpr(HirExpr.EDict(h_keys, h_vals, AstType.init("Dict")))
+            case Expr.EListComp(element, generators):
+                self.enter_scope()
+                mut hgens = Vec[Pointer[HirComprehension]].init(generators.len)
+                mut gc: int = 0
+                while gc < generators.len:
+                    mut gen_ast: Comprehension = generators.get(gc).read()
+                    mut hgen_ptr = alloc[HirComprehension](1)
+                    mut hgen_val = HirComprehension()
+                    hgen_val.target = gen_ast.target
+                    mut h_iter_lc = self.lower_expr(gen_ast.iter)
+                    hgen_val.iter = h_iter_lc
+                    mut lc_itn = hir_expr_type(h_iter_lc).name
+                    mut lc_ial = hir_expr_type(h_iter_lc).args.len
+                    mut lc_elem_ty = AstType.init("int")
+                    if (lc_itn == "List" or lc_itn == "Vec") and lc_ial > 0:
+                        lc_elem_ty = hir_expr_type(h_iter_lc).args.get(0).read()
+                    elif lc_itn == "str":
+                        lc_elem_ty = AstType.init("char")
+                    self.declare(gen_ast.target, SymbolKind.SVariable, box_asttype(lc_elem_ty), false)
+                    mut hifs = Vec[Pointer[HirExpr]].init(gen_ast.ifs.len)
+                    mut lc_fi = 0
+                    while lc_fi < gen_ast.ifs.len:
+                        hifs.push(self.lower_expr(gen_ast.ifs.get(lc_fi)))
+                        lc_fi = lc_fi + 1
+                    hgen_val.ifs = hifs
+                    hgen_val.is_async = gen_ast.is_async
+                    hgen_ptr.write(hgen_val)
+                    hgens.push(hgen_ptr)
+                    gc = gc + 1
+                mut h_lc_elem = self.lower_expr(element)
+                mut lc_elem_hty = hir_expr_type(h_lc_elem)
+                mut comp_ty = AstType.init("List")
+                comp_ty.args = Vec[Pointer[AstType]].init(1)
+                comp_ty.args.push(box_asttype(lc_elem_hty))
+                self.exit_scope()
+                return box_hirexpr(HirExpr.EListComp(h_lc_elem, hgens, comp_ty))
+            case Expr.EGeneratorExpr(element, generators):
+                self.enter_scope()
+                mut hgens2 = Vec[Pointer[HirComprehension]].init(generators.len)
+                mut gc2: int = 0
+                while gc2 < generators.len:
+                    mut gen_ast2: Comprehension = generators.get(gc2).read()
+                    mut hgen_ptr2 = alloc[HirComprehension](1)
+                    mut hgen_val2 = HirComprehension()
+                    hgen_val2.target = gen_ast2.target
+                    mut h_iter_ge = self.lower_expr(gen_ast2.iter)
+                    hgen_val2.iter = h_iter_ge
+                    mut ge_itn = hir_expr_type(h_iter_ge).name
+                    mut ge_ial = hir_expr_type(h_iter_ge).args.len
+                    mut ge_elem_ty = AstType.init("int")
+                    if (ge_itn == "List" or ge_itn == "Vec") and ge_ial > 0:
+                        ge_elem_ty = hir_expr_type(h_iter_ge).args.get(0).read()
+                    elif ge_itn == "str":
+                        ge_elem_ty = AstType.init("char")
+                    self.declare(gen_ast2.target, SymbolKind.SVariable, box_asttype(ge_elem_ty), false)
+                    mut hifs2 = Vec[Pointer[HirExpr]].init(gen_ast2.ifs.len)
+                    mut ge_fi = 0
+                    while ge_fi < gen_ast2.ifs.len:
+                        hifs2.push(self.lower_expr(gen_ast2.ifs.get(ge_fi)))
+                        ge_fi = ge_fi + 1
+                    hgen_val2.ifs = hifs2
+                    hgen_val2.is_async = gen_ast2.is_async
+                    hgen_ptr2.write(hgen_val2)
+                    hgens2.push(hgen_ptr2)
+                    gc2 = gc2 + 1
+                mut h_ge_elem = self.lower_expr(element)
+                mut ge_elem_hty = hir_expr_type(h_ge_elem)
+                mut gen_ty = AstType.init("List")
+                gen_ty.args = Vec[Pointer[AstType]].init(1)
+                gen_ty.args.push(box_asttype(ge_elem_hty))
+                self.exit_scope()
+                return box_hirexpr(HirExpr.EGeneratorExpr(h_ge_elem, hgens2, gen_ty))
+            case Expr.ESuperMethodCall(base_class, method, args):
+                mut h_super_args = Vec[Pointer[HirExpr]].init(4)
+                mut k_smc: int = 0
+                while k_smc < args.len:
+                    h_super_args.push(self.lower_expr(args.get(k_smc)))
+                    k_smc = k_smc + 1
+                # Infer base class from current class if not explicit
+                mut resolved_base: str = base_class
+                if resolved_base == "" and self.current_class_name != "":
+                    if self.classes.contains(self.current_class_name):
+                        mut cur_cls: ClassDef = self.classes.get(self.current_class_name)
+                        if cur_cls.base_classes.len > 0:
+                            resolved_base = cur_cls.base_classes.get(0)
+                mut super_ret_ty = AstType.init("void")
+                if self.classes.contains(resolved_base):
+                    mut bc_def: ClassDef = self.classes.get(resolved_base)
+                    mut k_smc2: int = 0
+                    while k_smc2 < bc_def.methods.len:
+                        if bc_def.methods.get(k_smc2).name == method:
+                            if bc_def.methods.get(k_smc2).ret_ty as usize != 0 as usize:
+                                super_ret_ty = bc_def.methods.get(k_smc2).ret_ty.read()
+                        k_smc2 = k_smc2 + 1
+                return box_hirexpr(HirExpr.ESuperMethodCall(resolved_base, method, h_super_args, super_ret_ty))
+            case Expr.ESuperPropAccess(base_class, prop):
+                mut resolved_base2: str = base_class
+                if resolved_base2 == "" and self.current_class_name != "":
+                    if self.classes.contains(self.current_class_name):
+                        mut cur_cls2: ClassDef = self.classes.get(self.current_class_name)
+                        if cur_cls2.base_classes.len > 0:
+                            resolved_base2 = cur_cls2.base_classes.get(0)
+                mut super_field_ty = AstType.init("void")
+                if self.classes.contains(resolved_base2):
+                    mut bc_def2: ClassDef = self.classes.get(resolved_base2)
+                    mut k_spa: int = 0
+                    while k_spa < bc_def2.fields.len:
+                        if bc_def2.fields.get(k_spa).name == prop:
+                            if bc_def2.fields.get(k_spa).ty as usize != 0 as usize:
+                                super_field_ty = bc_def2.fields.get(k_spa).ty.read()
+                        k_spa = k_spa + 1
+                return box_hirexpr(HirExpr.ESuperPropAccess(resolved_base2, prop, super_field_ty))
             case _: return box_hirexpr(HirExpr.ELitNone(AstType.init("None")))
 
     # ── Rule N-1: Reserved name helpers ───────────────────────────────────────


### PR DESCRIPTION
Bugs fixed:

  1. super() parsing — super is tokenized as Token.KwSuper, not Token.Ident("super"). The old super-handling code inside
   the Ident case was completely dead. Added a proper case Token.KwSuper: in parse_primary that handles both
  super(ClassName).method() and super.ClassName.method() syntax.
  2. in / not in operators — Was always generating _tr_contains(ls, rs) (string substring check) regardless of container
   type, AND the argument order was reversed. Fixed:
    - x in List[T] → List_T_contains(list, x)
    - x in Map[V] → _tr_dict_contains(map, x)
    - "needle" in str → _tr_contains(str, "needle") (arg order corrected)