### PR TITLE
docs: add AI-friendly documentation files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ bootstrap/*.zip
 !bootstrap/c/
 !bootstrap/c/**
 
+# AI-friendly documentation indexes (not debug output)
+!llms*.txt
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,117 @@
+# Tauraro — AI Contribution Guide
+
+## Project Overview
+
+Self-hosted compiled language with Python syntax + bilingual (English/Hausa) keywords. Compiles to C → native via GCC/Clang. ~13,700 LOC compiler, ~8,000 LOC stdlib. Version 0.0.5.
+
+**Key constraint:** All compiler source is written in Tauraro itself (`.tr` files). The bootstrap chain is: `bootstrap/c/main.c` (portable C seed) → stage0 → `src/main.tr` → final `tauraroc` binary.
+
+## Compiler Pipeline
+
+```
+source.tr → Lexer (src/lexer.tr, 677L)
+         → Parser (src/parser.tr, 2,259L)
+         → Sema  (src/sema.tr, 2,498L)     ← type-checking + ownership inference
+         → HIR   (src/hir.tr, 296L)        ← typed intermediate representation
+         → Codegen (src/codegen/c.tr, 5,697L)  ← emits per-module .c files
+         → GCC/Clang → native binary
+```
+
+## Source Map
+
+| File | LOC | Role |
+|------|-----|------|
+| `main.tr` | 830 | CLI driver, arg parsing, pipeline orchestration, C linking |
+| `token.tr` | 359 | Token enum (185 variants) — literals, keywords (EN+HA), operators, delimiters, indentation |
+| `lexer.tr` | 677 | Tokenizer with indentation tracking, bilingual keyword mapping |
+| `parser.tr` | 2,259 | Recursive-descent parser — all features (async, generics, GPU, unsafe, closures, comprehensions) |
+| `ast.tr` | 483 | AST nodes — Decl (11 variants), Expr (40+), Stmt (25+), Pattern |
+| `sema.tr` | 2,498 | Semantic analysis — type checking, ownership inference (M-1..M-7 rules), scope management, HIR lowering |
+| `hir.tr` | 296 | HIR types — HirExpr (45 variants), HirStmt (26 variants), HirProgram |
+| `resolver.tr` | 240 | Unity-build module resolver — search paths, pub/private filtering |
+| `codegen/c.tr` | 5,697 | C backend — per-module .c generation, monomorphization, runtime header |
+| `codegen/llvm.tr` | 362 | LLVM IR backend (experimental, text-IR skeleton) |
+
+## Key Architecture Decisions
+
+1. **Unity-build model:** All imports resolved into a single flat declaration list by the resolver. No separate compilation units for Tauraro modules — each module gets its own `.c` file, but the C compiler links all at once.
+
+2. **Automatic ownership:** Sema infers Own/Borrow/Move/Shared/Stack for every variable and injects `free()` at scope exit. No lifetime annotations needed (except `from` for special pointer-return cases).
+
+3. **Zero-cost abstractions:** Classes → C structs, methods → `ClassName_method()` functions, interfaces → vtable structs (one deref per virtual call), generics → monomorphized per type combo.
+
+4. **Bilingual keywords:** Every keyword has EN and HA forms (e.g. `def`/`aiki`, `class`/`aji`, `if`/`idan`). Lexer's `keyword_to_token()` maps both to the same token variant. Programs can mix freely.
+
+5. **`@copy` annotation:** Arena-allocated types (like `AstType`) annotated with `@copy` to opt out of move semantics — they're never individually freed.
+
+## Coding Conventions
+
+- Files start with `# comment` header describing purpose
+- Classes: `pub class Name:`
+- Extend blocks: `extend Name:` for methods (separated from field declarations)
+- Methods: `pub def method_name(self, param: Type) -> ReturnType:`
+- Boxing: `box_expr()`, `box_stmt()`, `box_decl()`, `box_asttype()` — heap-allocates wrappers for AST/HIR nodes
+- Enum variants: PascalCase (`ELitInt`, `SLet`, `DClass`)
+- Variables/functions: snake_case
+- Constants: PascalCase or UPPER_CASE (inconsistent — follow existing pattern in file)
+- Match exhaustiveness: always include `case _: pass` as default unless all variants handled
+- Null pointer sentinel: `Pointer[T](0)` for zeroed pointers
+
+## Ownership Rules (Compiler Error Codes)
+
+- **M-1:** Heap allocation not tracked — always bind `alloc()` to named variable
+- **M-2:** Use after move — access before consuming or use `clone()`
+- **M-3:** No double-free — don't manually free Own variables
+- **M-4:** No dangling pointers — don't return refs to locals
+- **M-5:** No aliased mutation — don't mutate while borrow active
+- **M-6:** Immutable by default — add `mut` to reassign
+- **M-7:** None requires Option[T] or pointer type
+- **T-1 through T-5:** Type rules — use explicit `as` casts, match types
+- **F-1/F-2/F-3:** Function rules — arg count, undefined calls, missing returns
+- **U-1:** alloc/dealloc outside `unsafe:` (only with `--strict`)
+
+## Build System
+
+```bash
+# Bootstrap build (requires existing tauraroc binary):
+export BOOTSTRAP_BIN=/path/to/tauraroc
+bash scripts/build.sh
+
+# Or with tauraroc on PATH:
+bash scripts/build.sh
+
+# Output: ./tauraroc
+
+# CI equivalent: .github/workflows/build.yml
+# Builds on ubuntu/windows/macos via scripts/build.sh / build.ps1
+```
+
+CI artifacts: binary + `src/`, `std/`, `runtime/`, `examples/`, `benchmarks/` in release zips.
+
+## Cross-Compilation Targets
+
+Shorthands: android-arm64, android-arm32, ios, ios-sim, linux-arm64/arm32/x86_64/riscv64, windows-x64/arm64, macos-arm64/x86_64, embedded-arm/arm64/riscv32/riscv64, wasm, wasm-wasi. Raw LLVM triples also accepted.
+
+## Standard Library Structure
+
+`std/` — 16 subdirectories, ~8,000 LOC total. Opaque handle pattern (`handle: Pointer[char]` → heap-allocated C struct). Import via `from std.module.submodule import Name`.
+
+Key modules: core (vec, map, string, alloc, io), async (channel, task, mutex, semaphore, barrier, group, poll, event_loop), collections (stack, queue, deque, set, heap, graph, list, dict), io (file, dir, path, console, buffer), net (tcp, udp, dns, url, http, https, server), math (int, float, stat, random, complex), sys (env, fs, process, time, os), string (str, fmt), encoding (json, base64, hex), crypto (sha256, hmac, md5, uuid), regex, test, unicode, compress (zlib), gpu.
+
+## Bilingual Keyword Table
+
+EN keyword(s) → Hausa counterpart(s):
+def→aiki, class→aji, struct→tsari, if→idan, elif→koidan, else→sai, for→ga, while→yayinda, return→dawo, break→tsaya, continue→ci_gaba, pass→wuce, match→duba, case→hali, try→gwada, except→kama, finally→karshe, raise→jefa, assert→tabbatar, with→tare, async→ba_jira, await→jira, yield→bayar, import→shigo, from→daga, as→kamar, in→a_cikin/ciki, and→da, or→ko, not→ba, print→buga, pub→fito, lambda→dan_aiki, true→gaskiya, false→karya, none→babu.
+
+## Common Contribution Patterns
+
+- **Add a new AST node:** Add variant to `Expr`/`Stmt`/`Decl` enum in `ast.tr`, add parsing in `parser.tr`, add lowering in `sema.tr`, add HIR variant in `hir.tr`, add codegen in `codegen/c.tr`.
+- **Add a new keyword:** Add to `keyword_to_token()` in `lexer.tr`, add token variant in `token.tr` (both EN and HA forms), handle in parser, add debug() output.
+- **Add a type:** Add type keyword tokens, handle in parser's type parsing, add type checking in `sema.tr`, add C type mapping in `codegen/c.tr`.
+- **Fix ownership bug:** Look at `sema.tr` — ownership inference happens during HIR lowering. Rules M-1 through M-7 enforced there.
+- **Fix codegen bug:** Look at `codegen/c.tr` — check the specific expression/statement handler.
+- **New backend:** Add to `codegen/` directory, register in `codegen/mod.tr`, add `--backend` flag handling in `main.tr`.
+
+## Testing
+
+Tests use `std.test` framework. Example programs in `examples/` (29 annotated examples) serve as integration tests. Benchmarks in `benchmarks/` validate correctness via output comparison. Run `tauraroc --check file.tr` for semantic-only validation.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1,0 +1,256 @@
+# Tauraro — Full AI-Friendly Documentation
+
+> Compiled, statically-typed systems programming language with Python-style indentation syntax. Compiles to C then native machine code via GCC/Clang. First language with full bilingual keyword support (English + Hausa). Self-hosted compiler written entirely in Tauraro. Automatic memory management via ownership inference — no borrow checker annotations, no GC, no manual free.
+
+Important context: Tauraro uses a unity-build model — all imports are resolved into a single flat declaration list. Ownership is inferred automatically by the semantic analyzer. Zero-cost abstractions throughout. The C backend is mature (5,697 lines); the LLVM IR backend is experimental (362 lines). The compiler is fully self-hosted — `tauraroc` compiles `src/main.tr` to produce itself.
+
+<doc title="CLI Reference" path="docs/lang/01_intro.md">
+CLI: `tauraroc <file.tr> [options]`
+Flags: --version, --run, --check, --emit c|ast|mir, --backend llvm, -o <path>, -O0/-O1/-O2/-O3/-Os, --verbose, --static, --debug (ASAN), --strict, --target <triple>, --sysroot <path>, --link <path>, -l<name>, --target (android-*, ios, linux-*, windows-*, macos-*, embedded-*, wasm-*).
+Env: TAURARO_PATH — extra module search paths (colon-separated on POSIX, semicolon on Windows).
+Compiler pipeline: .tr → Lexer → Parser → AST → Sema (type-check + ownership) → HIR → C Codegen → GCC/Clang → native binary.
+Self-hosted: bootstrap via portable C seed (bootstrap/c/), then compiler compiles itself.
+</doc>
+
+<doc title="Variables & Types" path="docs/lang/02_variables_and_types.md">
+Variables immutable by default. Use `mut` for mutable bindings. `const` for compile-time constants.
+Type inference with explicit `: Type` annotations available. All type conversions use explicit `as` cast — no implicit coercion.
+
+Primitive types: int (i64), float (f64), bool, char (1 byte), str (pointer).
+Fixed-width: i8/i16/i32/i64/i128, u8/u16/u32/u64/u128, isize/usize, f32/f64.
+Compound: List[T], Vec[T], Dict, Map[K,V], Set[T], Pointer[T], Result[T,E], Option[T], Shared[T], Chan[T], Mutex[T], Atomic[T].
+
+Nil literal: `none` requires Option[T] or pointer type (rule M-7).
+</doc>
+
+<doc title="Operators" path="docs/lang/03_operators.md">
+Arithmetic: +, -, *, /, %, ** (power), // (floor div), +=, -=, *=, /=, %=, **=, //=.
+Comparison: ==, !=, <, >, <=, >=.
+Bitwise: &, |, ^, ~, <<, >>, &=, |=, ^=, <<=, >>=.
+Logical: and, or, not (short-circuiting).
+Other: `as` (cast), `is` (type check), `in` / `not in` (membership), `..` (range), `..=` (inclusive range), `...` (spread), `->` (return type), `=>` (fat arrow), `?` (error propagation).
+Ternary: `if cond then_expr else else_expr`.
+</doc>
+
+<doc title="Control Flow" path="docs/lang/04_control_flow.md">
+if/elif/else: `if cond: ... elif cond2: ... else: ...`
+while: `while cond: ...`
+for: `for var in iterable: ...` — works with ranges (`range(n)`), List, Vec, Set, Dict, str, and any type implementing `__iter__`/`__next__`.
+break/continue: standard semantics.
+match/case: pattern matching with destructuring. `match val: case Pattern: ... case _: ...`
+Patterns: literal, variable binding, enum variant destructuring, tuple destructuring, wildcard `_`.
+</doc>
+
+<doc title="Functions" path="docs/lang/05_functions.md">
+def: `def name(params) -> ReturnType:`
+Parameters: typed `param: Type`. No default parameters.
+Return: explicit `-> Type` or omitted for void. Rule F-3: all code paths must return.
+Throws: `def fn() throws -> T` — errors propagate via `?` operator.
+Generics: `def fn[T](x: T) -> T`
+Async: `async def fn() -> T` — must use `await` inside. Rules C-4/C-5/C-6 enforce async context.
+Closures: `\|params\| expr` or `\|params\| { block }` with captures (by reference default).
+Decorators: `@inline`, `@hot`, `@property`, custom decorators with arguments.
+Variadic functions: FFI only via `extern "C"` blocks.
+</doc>
+
+<doc title="Strings & F-Strings" path="docs/lang/06_strings.md">
+String literals: double-quoted `"..."`, raw `r"..."`, triple-quoted `"""..."""`, byte `b"..."`, f-strings `f"..."`.
+Escape sequences: \n, \t, \\, \", \0, \xNN, \uNNNN.
+F-string interpolation: `f"value = {expr}"` — zero overhead, compiled to string concatenation at compile time.
+String methods: len(), index_of(), slice(), trim(), contains(), starts_with(), ends_with(), replace(), split(), to_int(), to_float().
+</doc>
+
+<doc title="Collections" path="docs/lang/07_collections.md">
+List[T]: `[1, 2, 3]` — growable typed array. Methods: append(), get(), set(), len(), sort(), reverse(), contains(), index_of(), insert(), remove(), clear(), filter(), map(), fold(), join().
+Dict: `{"key": value}` — string-keyed hash map (built-in). Also Map[K,V] from std.core.map for typed keys.
+Set[T]: `{1, 2, 3}` — unordered unique collection. Methods: add(), remove(), contains(), union(), intersection(), difference().
+Tuple: `(a, b, c)` — fixed-size heterogeneous group.
+Comprehensions: `[expr for var in iterable]`, `[expr for var in iterable if cond]`, `{k: v for ...}`, `{expr for ...}`.
+</doc>
+
+<doc title="Classes & Extend" path="docs/lang/08_classes.md">
+Separate data (`class`) from behavior (`extend`). class declares fields only. extend adds methods.
+Fields: typed `pub name: Type`. Private by default; `pub` makes them accessible outside the module.
+Methods: first parameter `self` gives instance access. Static methods omit self.
+Init: convention `pub def init(args) -> ClassName` — returns new instance.
+Inheritance: `class Child extends Parent:` — single inheritance. `super.method()` for parent calls.
+Multiple extend blocks allowed — organize by concern.
+Method dispatch: static by default. Dynamic dispatch only via interfaces (vtables).
+Dunder methods: __add__, __sub__, __mul__, __str__, __repr__, __iter__, __next__, __getitem__, __setitem__, __len__, __enter__, __exit__, __contains__.
+</doc>
+
+<doc title="Enums" path="docs/lang/09_enums.md">
+Algebraic data types with named variants. `enum Name: Variant1(args) Variant2(args)`
+Pattern matching: `match val: case Enum.Variant(a, b): ...`
+Variants can carry data (tagged union — no heap allocation).
+Compiled to C structs with a discriminant tag and union payload.
+</doc>
+
+<doc title="Interfaces" path="docs/lang/10_interfaces.md">
+`interface IName:` — method signatures only, no fields, no defaults.
+`class Foo: ... extend Foo: pub def method(self) -> void: ... implements IFoo:`
+implements block: provides vtable method bindings — maps class methods to interface signatures.
+Dynamic dispatch via vtable struct (one pointer dereference per virtual call).
+`is` operator for runtime type checking against interfaces.
+Interface names conventionally start with `I`.
+</doc>
+
+<doc title="Generics" path="docs/lang/11_generics.md">
+`def fn[T](x: T) -> T` — type parameters in square brackets.
+Multiple params: `def fn[A, B](a: A) -> B`.
+Generic classes: `class Box[T]: pub value: T`.
+Where clauses: `def fn[T](x: T) where T: SomeInterface`.
+Monomorphization at compile time — separate C function/struct per concrete type combination. Zero runtime cost.
+</doc>
+
+<doc title="Error Handling" path="docs/lang/12_error_handling.md">
+try/except/finally: `try: ... except e: ... finally: ...`
+throws: `def fn() throws -> T` marks functions that can fail.
+`?` operator: `result = try fn()?` — propagates errors to caller.
+Result[T,E]: `Ok(value)` or `Err(error)` — returned by `throws` functions.
+Warnings: unhandled Result values generate compiler warning.
+</doc>
+
+<doc title="Memory & Ownership" path="docs/lang/13_memory_and_ownership.md">
+Automatic ownership inference. Five states: Own (heap owned, free at scope exit), Borrow (temporary ref), Move (ownership transferred), Shared (refcounted), Stack (scalar/stack value).
+Rules: M-1 (auto inference), M-2 (no use-after-move), M-3 (no double-free), M-4 (no dangling pointers), M-5 (no aliased mutation), M-6 (immutable by default), M-7 (none requires Option).
+clone(x) — deep copy. shared keyword — refcounted ownership.
+ownership system tracks all safe code; inside unsafe: blocks, raw pointers are untracked.
+</doc>
+
+<doc title="Unsafe & Pointers" path="docs/lang/14_unsafe_and_pointers.md">
+`unsafe:` block — scope for operations the compiler cannot verify.
+Operations: &x (address-of), p.read(), p.write(v), p.offset(n) (pointer arithmetic), alloc[T](n), dealloc(ptr), asm(), casts to/from Pointer[T].
+Pointer[T]: generic raw pointer. Methods: read(), write(), offset().
+`voidptr` / `Pointer[void]` for type-erased pointers.
+--strict flag: alloc/dealloc outside unsafe is error U-1.
+Inside unsafe: type checking still active, ownership tracking still protects outer-scope bindings.
+</doc>
+
+<doc title="Modules" path="docs/lang/15_modules.md">
+import/from: `import module`, `from module import name`, `from module import name as alias`.
+Unity-build model: all imports resolved into flat declaration list by the resolver.
+Module resolution: search paths = binary dir, TAURARO_PATH env var, CWD.
+`pub` makes items visible outside module. `export` re-exports from sub-modules.
+Package layout: `packagename/mod.tr` (directory module) or `packagename.tr` (file module).
+Dotted paths: `from std.collections.vec import Vec`.
+</doc>
+
+<doc title="Concurrency" path="docs/lang/16_concurrency.md">
+Primitives: async def / await, spawn, task_group:, await_all(), await_timeout(), Chan[T], Mutex[T], RwLock[T], Atomic[T], ThreadLocal[T], Shared[T], Sendable, StructuredGroup, IOPoll/EventLoop, Pool.
+Compile-time safety: T-1 (Sendable check on spawn), T-2 (race detection), T-3 (deadlock detection).
+Channels: `chan = Chan[T].init(capacity)` — typed send/receive.
+Async functions: `async def fn() -> T` — await can only appear in async context.
+</doc>
+
+<doc title="Extern & FFI" path="docs/lang/17_extern_and_ffi.md">
+`extern "C":` block for C ABI declarations. Functions declared without body.
+Type mapping: int→i64, float→double, str→const char*, Pointer[T]→T*.
+`--link <path>` and `-l<name>` for linking external libraries.
+Variadic functions: `fn(format: str, ...)` — C varargs support.
+</doc>
+
+<doc title="GPU & Inline Assembly" path="docs/lang/18_gpu_and_asm.md">
+`gpu:` block — compiles to OpenMP `#pragma omp parallel for`. Requires `-fopenmp` flag.
+`asm("instructions")` — inline assembly (compiler-specific syntax, passed through to C).
+Memory barriers: `__sync_synchronize()`.
+</doc>
+
+<doc title="Compiler Error Reference" path="docs/lang/19_compiler_errors.md">
+M-series (Memory): M-1 (allocation not tracked), M-2 (use after move), M-3 (double free), M-4 (dangling pointer), M-5 (null dereference), M-6 (assign to immutable), M-7 (none on value type).
+T-series (Type): T-1 (no implicit coercion), T-2 (type mismatch), T-3 (wrong arg type), T-4 (return type mismatch), T-5 (cannot infer type).
+N-series (Name): N-1 (reserved name used as declaration).
+F-series (Function): F-1 (wrong arg count), F-2 (undefined call), F-3 (missing return).
+U-series (Unsafe): U-1 (alloc outside unsafe with --strict).
+Concurrency: C-4 (await outside async), C-5 (spawn outside async), C-6 (task_group outside async).
+</doc>
+
+<doc title="Advanced Patterns" path="docs/lang/20_advanced_patterns.md">
+Singleton pattern: use static class with private constructor.
+Factory pattern: static init method returning new instance.
+Builder pattern: method chaining with `self` returns.
+RAII: ownership system provides deterministic cleanup at scope exit.
+Visitor pattern: interfaces + dynamic dispatch.
+Performance: prefer Vec over List for small collections, use stack allocation when possible, avoid cloning in hot paths.
+</doc>
+
+<doc title="Operator Overloading" path="docs/lang/21_operator_overloading.md">
+Dunders: __add__, __sub__, __mul__, __div__, __mod__, __pow__, __neg__, __pos__, __str__, __repr__, __iter__, __next__, __getitem__, __setitem__, __len__, __enter__, __exit__, __contains__, __eq__, __ne__, __lt__, __le__, __gt__, __ge__, __hash__.
+Implemented inside `extend` blocks. Each dunder has a specific signature convention.
+`with` statement uses __enter__/__exit__ for context managers.
+</doc>
+
+<doc title="Standard Library" path="docs/std/README.md">
+std.async — Channels (Chan, Task, Mutex, Semaphore, Barrier, StructuredGroup, IOPoll, EventLoop, Pool).
+std.collections — Stack, Queue, Deque, Set (union/intersection/difference), Counter, Pair/Triple, MinHeap/MaxHeap, LinkedList, Graph (BFS/DFS/topological sort).
+std.compress — zlib compress/decompress, raw deflate/inflate. Requires `-lz` linker flag.
+std.crypto — SHA-256, HMAC-SHA256, MD5, UUID v4.
+std.encoding — JSON parser/serializer, Base64 encode/decode, Hex encode/decode.
+std.io — File I/O (read/write/append), directory operations (mkdir/rmdir/listdir), path manipulation, console (print/input/color), buffered readers/writers.
+std.iter — Range construction, int/float vector transforms (map/filter/reduce), prefix sums, min/max/mean, normalization.
+std.math — Integer GCD/LCM, prime testing, bit counting, floating-point trig/log/exp, statistics (mean/variance/stdev), random (shuffle/sample), complex numbers.
+std.net — TCP (listen/connect/send/recv), UDP, DNS resolution, URL parsing, HTTP client (7 verbs), HTTPS client (OpenSSL), HTTP server + router (routes/middleware/JSON).
+std.regex — POSIX extended regex: match, find_all, replace, split, count.
+std.string — Str class (case conversion, padding, splitting, word count), Fmt class (printf-style formatting).
+std.sys — env vars, file system (exists/type/size/permissions/rename/copy/remove), process (spawn/exec/kill/wait), timing (now/sleep/timer), OS info, platform detection.
+std.test — Lightweight unit-testing: test! macro, assert_eq, assert_ne, assert_approx, test groups, suite runner.
+std.unicode — UTF-8 codepoint iteration, slice by codepoint, case conversion, Unicode classification (is_alpha/is_digit/is_space/is_punct).
+</doc>
+
+<doc title="Benchmarks" path="benchmarks/README.md">
+Tauraro vs C vs Rust on 10 compute workloads. Key results: Tauraro beats C on 8/9 benchmarks, ties/beats Rust on 5/10.
+Fibonacci 1B: Tauraro 0.51x C, 1.12x Rust. MatMul 400x400: 0.51x C, 1.00x Rust. Mandelbrot: 0.96x C, 0.90x Rust.
+Flags: tauraroc -O3 passes -march=native -funroll-loops to GCC.
+Benchmarks: integer sum, fibonacci, float mul, xorshift, newton sqrt, mandelbrot, sieve, nbody, collatz, matmul.
+</doc>
+
+<doc title="Compiler Source — main.tr" path="src/main.tr">
+830 lines. Entry point + CLI driver. Parses args, orchestrates pipeline: resolve → lex → parse → sema → codegen → compile. Handles all CLI flags, cross-compilation, module search paths (binary dir, TAURARO_PATH, CWD), runtime header resolution (multiple fallback paths), C compilation (auto-detects gcc/clang/cc), build directory management. Key functions: detect_c_compiler(), resolve_target_triple(), compile_all_c(), read_runtime_header().
+</doc>
+
+<doc title="Compiler Source — token.tr" path="src/token.tr">
+359 lines. Token enum with 185 variants. Categories: literals (IntLit, FloatLit, StrLit, TripleStrLit, ByteStrLit, RawStrLit, CharLit, FStrLit, BoolLit), keywords (52 English + Hausa equivalents), operators (arithmetic, comparison, bitwise, assignment), delimiters (parens, brackets, braces, colon, comma, semicolon, hash), indentation (Indent/Dedent/Newline). Helpers: is_eof(), is_newline(), is_keyword(), debug().
+</doc>
+
+<doc title="Compiler Source — lexer.tr" path="src/lexer.tr">
+677 lines. Recursive lexer with indentation tracking. keyword_to_token() maps English+Hausa keyword strings to Token variants. Handles: integer/float literals (including hex/octal/binary), string literals (normal/raw/triple/byte/f-string), char literals, operators, indentation counting for Python-style blocks. Produces Vec[Token] with Indent/Dedent tokens.
+</doc>
+
+<doc title="Compiler Source — parser.tr" path="src/parser.tr">
+2,259 lines. Recursive-descent parser. Classes: Parser with peek(), advance(), match_tok(), expect_tok(). Methods: parse_program(), parse_decl() (function/class/enum/interface/extend/import), parse_stmt() (if/while/for/match/try/with/asm/gpu/defer/return/break/continue/raise/spawn/task_group/chan_select/assign/expr), parse_expr() (full precedence climbing: ternary → or → and → comparison → bitwise → arithmetic → unary → power → call/member → primary), parse_pattern(), parse_type(). Handles all language features including async, generics, decorators, closures, comprehensions.
+</doc>
+
+<doc title="Compiler Source — ast.tr" path="src/ast.tr">
+483 lines. AST node definitions. Key types: AstType (with name, generic args, from_param lifetime), GenericConstraint, Decorator, Program (list of Decls), Decl enum (DFunction, DClass, DEnum, DInterface, DExtend, DImport, DFromImport, DExtern, DExternFn, DConst, DStruct, DExport, DDecorator, DActor), Expr enum (40+ variants), Stmt enum (25+ variants), Pattern enum, Block, Ownership enum (Own/Borrow/Move/Shared/Stack). @copy annotation on AstType for arena-allocation safety.
+</doc>
+
+<doc title="Compiler Source — sema.tr" path="src/sema.tr">
+2,498 lines. Semantic analyzer — largest non-codegen file. Key classes: SymbolKind (SFunction/SClass/SEnum/SVariable/SInterface), Symbol (name, kind, type, scope info, ownership state), Scope (variable map). Sema class holds type environment, function signatures, class layouts. Methods: analyze(Program) → HirProgram, type inference, ownership analysis (M-1 through M-7), scope management, error reporting. Generates HIR from validated AST. Tracks: symbols, types, ownership states, borrow lifetimes, move semantics.
+</doc>
+
+<doc title="Compiler Source — hir.tr" path="src/hir.tr">
+296 lines. HIR types. HirExpr enum (45 variants: ELitInt through EAddrOf). HirStmt enum (26 variants: SLet through SExpr). HirBlock, HirFunction, HirClass, HirEnum, HirInterface, HirProgram. Helper types: HirParam, HirField, HirVariant, HirFStringPart, HirCatchClause, HirComprehension, HirMatchArm, HirChanSelectArm. Helper functions: box_hirexpr(), box_hirstmt(), hir_expr_type().
+</doc>
+
+<doc title="Compiler Source — resolver.tr" path="src/resolver.tr">
+240 lines. Module resolver — unity-build model. ModuleResolver class with add_search_path() and resolve_main(). resolve_file(): reads source, lexes, parses, collects decls. resolve_module_path(): searches for mod.tr then .tr in search paths. Supports pub/private visibility filtering. Search order: TAURARO_PATH entries → binary dir → CWD.
+</doc>
+
+<doc title="Compiler Source — codegen/c.tr" path="src/codegen/c.tr">
+5,697 lines. C backend — largest file in compiler. CGenerator class with register_program(), scan_mono_prog(), generate_types_header(), generate_module_c(), generate_main_c(). Per-module C file generation: classes → C structs + ClassName_method() functions, interfaces → vtable structs + wrapper functions, enums → tagged unions, generics → monomorphized per type argument. Name sanitization (_safe_c_varname), pointer validity checks (_is_invalid_ptr for 0xbaadf00d, 0xcccccccc etc.), type classification helpers. Generates: build/tauraro_types.h, build/include/<path>.c (stdlib), build/module_<name>.c (user modules), build/main.c.
+</doc>
+
+<doc title="Compiler Source — codegen/llvm.tr" path="src/codegen/llvm.tr">
+362 lines. LLVM IR text backend. Mirrors Rust bootstrap version. Maps Tauraro types to LLVM types (int→i64, float→double, bool→i1, str→ptr). Experimental — not the default backend.
+</doc>
+
+<doc title="Build System" path="scripts/build.sh">
+41 lines. Bootstrap build: compiles src/main.tr using existing tauraroc binary. BOOTSTRAP_BIN env var or PATH lookup. ARM64 Linux: wraps musl-gcc for portable binary. --static flag. Output: ./tauraroc. Old bootstrap compat: moves src/build/tauraroc → ./tauraroc.
+Windows equivalent: scripts/build.ps1 (27 lines).
+CI: .github/workflows/build.yml (235 lines) — runs on push/PR across ubuntu, windows, macos. Stages: prepare bootstrap binary (compile bootstrap/c/main.c or download release), build, verify, upload artifact. Release on v* tags.
+Bootstrap chain: portable C seed (bootstrap/c/) → stage0 → src/main.tr → tauraroc binary.
+</doc>
+
+<doc title="Runtime" path="runtime/tauraro_rt.h">
+4,313 lines. C runtime header. Types: TR_String (length + data), TR_Vec (generic dynamic array), TR_Map (hash map). Memory: ref-counted allocations, TR_AllocHeader. Concurrency: TR_Mutex (pthreads/SRWLock/CriticalSection), TR_ConditionVar, TR_Thread, TR_Channel. Async: TR_Future, TR_Waker, TR_EventLoop (epoll/IOCP/kqueue). I/O: TR_File, TR_Buffer. Platform abstraction: Windows (WIN32) / POSIX / WASM.
+</doc>

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,76 @@
+# Tauraro
+
+> Compiled, statically-typed systems programming language with Python-style indentation syntax. Compiles to C then native machine code via GCC/Clang. First language with full bilingual keyword support (English + Hausa). Self-hosted compiler written entirely in Tauraro itself. Automatic memory management via ownership inference — no borrow checker annotations, no GC, no manual free. ~13,700 lines of compiler source, ~8,000 lines stdlib.
+
+Important context: Tauraro uses a unity-build model — all imports are resolved into a single flat declaration list. Ownership is inferred automatically by the semantic analyzer (every heap-allocated variable gets `free()` injected at scope exit). The compiler is self-hosted and bootstraps via a portable C seed. Zero-cost abstractions: classes → C structs, interfaces → vtable structs (one pointer dereference per virtual call), generics → monomorphized (no boxing). The C backend is mature (5,697 lines); the LLVM IR backend is a text-IR skeleton (362 lines).
+
+## Language Documentation
+
+- [Introduction](docs/lang/01_intro.md): Philosophy, compiler pipeline, CLI flags, quick start, cross-compilation, self-hosted bootstrap
+- [Variables & Types](docs/lang/02_variables_and_types.md): Mutability, type system, inference, all primitive types, literals
+- [Operators](docs/lang/03_operators.md): Arithmetic, bitwise, logical, comparison, cast (`as`), precedence table
+- [Control Flow](docs/lang/04_control_flow.md): if/elif/else, while, for, break/continue, match/case pattern matching
+- [Functions](docs/lang/05_functions.md): def, parameters, return types, throws, `?` operator, generics, async, closures, decorators
+- [Strings & F-Strings](docs/lang/06_strings.md): String literals (including raw/triple-quoted/byte), escape sequences, f-string interpolation, string methods
+- [Collections](docs/lang/07_collections.md): List[T], Dict, Set, Tuple, comprehensions, iteration protocols
+- [Classes & Extend](docs/lang/08_classes.md): class/extend split design, fields, methods, init, self, pub, static methods, dunder methods
+- [Enums](docs/lang/09_enums.md): Algebraic data types with variants, pattern matching with destructuring
+- [Interfaces](docs/lang/10_interfaces.md): interface, implements, vtable dispatch, polymorphism across class/enum types
+- [Generics](docs/lang/11_generics.md): Generic functions and classes, type parameters, where clauses, monomorphization at compile time
+- [Error Handling](docs/lang/12_error_handling.md): try/except/finally, throws annotation, Result[T,E] type, `?` propagation operator
+- [Memory & Ownership](docs/lang/13_memory_and_ownership.md): Ownership states (Own/Borrow/Move/Shared/Stack), M-1 through M-7 safety rules, clone(), shared ownership, unsafe blocks
+- [Unsafe & Pointers](docs/lang/14_unsafe_and_pointers.md): unsafe: blocks, Pointer[T], alloc/dealloc, pointer arithmetic, void pointers
+- [Modules](docs/lang/15_modules.md): import/from, pub/export, module resolution algorithm, TAURARO_PATH
+- [Concurrency](docs/lang/16_concurrency.md): async/await, spawn, task_group:, Chan[T], Mutex[T], Atomic[T], Sendable, StructuredGroup, IOPoll/EventLoop
+- [Extern & FFI](docs/lang/17_extern_and_ffi.md): extern "C" blocks, variadic functions, linking with -l and --link, ABI compatibility
+- [GPU & Inline Assembly](docs/lang/18_gpu_and_asm.md): gpu: blocks (OpenMP parallel loops), asm() for inline assembly, memory barriers
+- [Compiler Error Reference](docs/lang/19_compiler_errors.md): Every error code (M-1 through M-7, T-1 through T-5, N-1, F-1 through F-3, U-1) with cause, example, and fix
+- [Advanced Patterns](docs/lang/20_advanced_patterns.md): Idioms, design patterns, performance optimization, best practices matrix
+- [Operator Overloading](docs/lang/21_operator_overloading.md): Dunder methods: `__add__`, `__sub__`, `__str__`, `__iter__`, `__getitem__`, `__enter__`/`__exit__` for `with`
+
+### Advanced Topics
+
+- [Lifetimes (`from` keyword)](docs/lang/advanced/01_lifetimes.md): Borrow lifetime annotations, escape analysis, `-> T from param` for returning pointers into caller data
+- [Advanced Ownership](docs/lang/advanced/02_advanced_ownership.md): Move semantics deep dive, Shared[T] reference counting, explicit borrow patterns
+- [Channel Select](docs/lang/advanced/03_channel_select.md): `select:` blocks for multiplexed channels, timeout arms, fan-in/fan-out, non-blocking ops
+- [Generators](docs/lang/advanced/04_generators.md): Generator expressions `(x for x in ...)`, lazy evaluation (note: not currently supported via `yield`)
+- [Decorators](docs/lang/advanced/05_decorators.md): `@inline`, `@hot`, `@property`, custom decorators with arguments
+- [Sendable & Thread Safety](docs/lang/advanced/06_sendable.md): Sendable interface, compile-time thread-safety enforcement, StructuredGroup
+
+## Standard Library
+
+- [std.async](docs/std/async.md): Channels, tasks, mutexes, semaphores, barriers, StructuredGroup, IOPoll, EventLoop
+- [std.collections](docs/std/collections.md): Stack, Queue, Deque, Set (with algebra), Counter, Pair/Triple, MinHeap/MaxHeap, LinkedList, Graph
+- [std.compress](docs/std/compress.md): zlib compress/decompress, raw deflate/inflate (`-lz` linker flag required)
+- [std.crypto](docs/std/crypto.md): SHA-256, HMAC-SHA256, MD5, UUID v4 generation
+- [std.encoding](docs/std/encoding.md): JSON, Base64, Hex encoding/decoding
+- [std.io](docs/std/io.md): File I/O, directory operations, path manipulation, console I/O, buffered readers/writers
+- [std.iter](docs/std/iter.md): Range construction, int/float vector transforms, folds, prefix sums, normalization
+- [std.math](docs/std/math.md): Integer math, floating-point math, bitwise operations, statistics, random number generation
+- [std.net](docs/std/net.md): TCP, UDP, DNS resolution, URL parsing, HTTP client (7 verbs), HTTPS client (OpenSSL), HTTP server + router
+- [std.regex](docs/std/regex.md): POSIX extended regex: match, find, replace, split, count
+- [std.string](docs/std/string.md): String utilities (Str class), formatting (Fmt class), parsing, line/word splitting
+- [std.sys](docs/std/sys.md): Environment variables, filesystem operations, process control, timing, OS info, platform detection
+- [std.test](docs/std/test.md): Lightweight unit-testing framework
+- [std.unicode](docs/std/unicode.md): UTF-8 codepoint iteration, slicing, case conversion, Unicode classification
+
+## Compiler Source Code
+
+- [src/main.tr](src/main.tr): CLI driver — args, pipeline orchestration, C compilation/linking (830 lines)
+- [src/token.tr](src/token.tr): Token types — all literals, keywords (English+Hausa), operators, delimiters (359 lines)
+- [src/lexer.tr](src/lexer.tr): Lexer — tokenizer with indentation tracking, keyword recognition (677 lines)
+- [src/parser.tr](src/parser.tr): Recursive-descent parser — classes, enums, generics, match, async, GPU blocks, unsafe (2,259 lines)
+- [src/ast.tr](src/ast.tr): AST node definitions — Program, Decl, Expr, Stmt, AstType, Pattern (483 lines)
+- [src/sema.tr](src/sema.tr): Semantic analyzer — type checking, ownership inference, scope management, HIR lowering (2,498 lines)
+- [src/hir.tr](src/hir.tr): HIR definitions — typed intermediate representation, HirExpr (45 variants), HirStmt (26 variants), HirProgram (296 lines)
+- [src/resolver.tr](src/resolver.tr): Module resolver — imports, search paths, unity-build model (240 lines)
+- [src/codegen/c.tr](src/codegen/c.tr): C backend — per-module C file generation, monomorphization, runtime header (5,697 lines)
+- [src/codegen/llvm.tr](src/codegen/llvm.tr): LLVM IR text backend — experimental, mirrors Rust bootstrap (362 lines)
+
+## Examples
+
+29 annotated example programs in [examples/](examples/) covering every language feature from variables to async concurrency to FFI. Start with `01_variables_and_types.tr` through `28_first_class_functions.tr`.
+
+## Benchmarks
+
+10 benchmark suites in [benchmarks/](benchmarks/) comparing Tauraro vs C vs Rust: fibonacci, float multiply, Newton sqrt, Mandelbrot, sieve, N-body, matrix multiply, and more.


### PR DESCRIPTION
Add llms.txt, llms-full.txt per llmstxt.org spec and CLAUDE.md for AI agent contributions.

llms.txt — spec-compliant index linking all docs, std lib modules, src files llms-full.txt — full inline documentation with condensed content CLAUDE.md — AI contribution guide with source map, architecture, ownership rules, bilingual keyword table

Un-ignore llms*.txt in .gitignore (currently blocked by *.txt rule).