### PR TITLE
fix(std.io): add missing File.dir_exists() static method

### DIFF
--- a/std/io/file.tr
+++ b/std/io/file.tr
@@ -10,6 +10,7 @@ extern "C":
     def _tr_c_fseek(fp: Pointer[char], offset: int, whence: int) -> int
     def _tr_c_ftell(fp: Pointer[char]) -> int
     def _tr_c_malloc(size: int) -> Pointer[char]
+    def _tr_dir_exists(path: str) -> bool
 
 pub class File:
     pub path:    str
@@ -153,6 +154,9 @@ extend File:
             _tr_c_fclose(fp)
             return true
         return false
+
+    pub def dir_exists(path: str) -> bool:
+        return _tr_dir_exists(path)
 
     # Return file size without opening an instance.
     pub def file_size(path: str) -> int:


### PR DESCRIPTION
File.dir_exists(path) was used in downstream tooling (e.g. taupkg) but was never defined on the File class. Only Dir.exists() and the raw _tr_dir_exists() C binding existed.

Without this method, any call to File.dir_exists() silently resolves to an unknown symbol, causing directory checks to always return false and producing incorrect 'not found' errors even when the directory exists.

Adds _tr_dir_exists to the extern "C" block in file.tr and exposes it as a public static helper File.dir_exists(path: str) -> bool, consistent with the existing File.file_exists() pattern.